### PR TITLE
Make team id strings, allow to specify id on creation

### DIFF
--- a/scripts/init/database/db_load.sh
+++ b/scripts/init/database/db_load.sh
@@ -9,7 +9,7 @@ SELECT 'Database installed, schemaversion = ' || MAX(version) from schemaversion
 \! pwd
 \COPY organizations(id, name, description) FROM 'organizations.csv' (FORMAT csv)
 \COPY users(id, name, org_id) FROM 'users.csv' (FORMAT csv)
-\COPY teams(name, description, team_parent_id, org_id) FROM 'teams.csv' (FORMAT csv)
+\COPY teams(id, name, description, team_parent_id, org_id, path) FROM 'teams.csv' (FORMAT csv)
 \COPY team_members(user_id, team_id) FROM 'team_members.csv' (FORMAT csv)
 EOF"
 node scripts/init/database/testdata/loadPolicies.js

--- a/scripts/init/database/migrations/001.do.sql
+++ b/scripts/init/database/migrations/001.do.sql
@@ -32,19 +32,19 @@ CREATE TABLE users (
 );
 
 CREATE TABLE teams (
-  id              SERIAL UNIQUE,
+  id              VARCHAR(128) UNIQUE,
   name            VARCHAR(30) NOT NULL,
   description     VARCHAR(90),
-  team_parent_id  INT REFERENCES teams(id),
+  team_parent_id  VARCHAR(128) REFERENCES teams(id),
   org_id          VARCHAR REFERENCES organizations(id) NOT NULL,
-  path            LTREE DEFAULT (text2ltree(currval('teams_id_seq')::varchar))
+  path            LTREE NOT NULL
 );
 
 CREATE INDEX teams_path_gist_idx ON teams USING GIST (path);
 
 CREATE TABLE team_members (
-  team_id  INT REFERENCES teams(id) NOT NULL,
-  user_id  VARCHAR(128) REFERENCES users(id) NOT NULL,
+  team_id VARCHAR(128) REFERENCES teams(id) NOT NULL,
+  user_id VARCHAR(128) REFERENCES users(id) NOT NULL,
   CONSTRAINT team_member_link PRIMARY KEY(team_id, user_id)
 );
 
@@ -55,7 +55,7 @@ CREATE TABLE user_policies (
 );
 
 CREATE TABLE team_policies (
-  team_id   INT REFERENCES teams(id) NOT NULL,
+  team_id VARCHAR(128) REFERENCES teams(id) NOT NULL,
   policy_id INT REFERENCES policies(id) NOT NULL,
   CONSTRAINT team_policy_link PRIMARY KEY(team_id, policy_id)
 );

--- a/scripts/init/database/testdata/teams.csv
+++ b/scripts/init/database/testdata/teams.csv
@@ -1,6 +1,6 @@
-Admins,Administrators of the Authorization System,,WONKA
-Readers,General read-only access,,WONKA
-Authors,Content contributors,,WONKA
-Managers,General Line Managers with confidential info,,WONKA
-Personnel Managers,Personnel Line Managers with confidential info,4,WONKA
-Company Lawyer,Author of legal documents,3,WONKA
+1,Admins,Administrators of the Authorization System,,WONKA,1
+2,Readers,General read-only access,,WONKA,2
+3,Authors,Content contributors,,WONKA,3
+4,Managers,General Line Managers with confidential info,,WONKA,4
+5,Personnel Managers,Personnel Line Managers with confidential info,4,WONKA,5
+6,Company Lawyer,Author of legal documents,3,WONKA,6

--- a/service/lib/ops/teamOps.js
+++ b/service/lib/ops/teamOps.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Boom = require('boom')
+const uuid = require('uuid/v4')
 const db = require('./../db')
 const async = require('async')
 const policyOps = require('./policyOps')
@@ -8,6 +9,10 @@ const userOps = require('./userOps')
 const utils = require('./utils')
 const SQL = require('./../db/SQL')
 const mapping = require('./../mapping')
+
+function generateId () {
+  return uuid().replace(/-/g, '_')
+}
 
 function getId (obj) {
   return obj.id
@@ -28,10 +33,11 @@ function loadTeamDescendants (job, next) {
 }
 
 function insertTeam (job, next) {
+  const teamId = job.params.id || generateId()
 
   const sql = SQL`
     INSERT INTO teams (id, name, description, team_parent_id, org_id, path) VALUES (
-      DEFAULT,
+      ${teamId.toString()},
       ${job.params.name},
       ${job.params.description},
       ${job.params.parentId},
@@ -40,10 +46,10 @@ function insertTeam (job, next) {
 
   if (job.params.parentId) {
     sql.append(SQL`
-      (SELECT path FROM teams WHERE id = ${job.params.parentId}) || currval('teams_id_seq')::varchar
+      (SELECT path FROM teams WHERE id = ${job.params.parentId}) || ${teamId.toString()}
     `)
   } else {
-    sql.append(SQL`text2ltree(currval('teams_id_seq')::varchar)`)
+    sql.append(SQL`${teamId.toString()}`)
   }
 
   sql.append(SQL`)RETURNING id`)

--- a/service/routes/public/teams.js
+++ b/service/routes/public/teams.js
@@ -36,10 +36,11 @@ exports.register = function (server, options, next) {
     method: 'POST',
     path: '/authorization/teams',
     handler: function (request, reply) {
-      const { name, description, user } = request.payload
+      const { id, name, description, user } = request.payload
       const { organizationId } = request.udaru
 
       const params = {
+        id,
         name,
         description,
         parentId: null,
@@ -58,6 +59,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         payload: {
+          id: Joi.string().regex(/^[0-9a-zA-Z_]+$/).optional().description('The id to be used for the new team. Only alphanumeric characters and underscore are supported'),
           name: Joi.string().required().description('Name of the new team'),
           description: Joi.string().required().description('Description of new team'),
           user: Joi.object().optional().description('Default admin user to be added to the team').keys({
@@ -69,7 +71,7 @@ exports.register = function (server, options, next) {
           'authorization': Joi.any().required()
         }).unknown()
       },
-      description: 'Create a teams',
+      description: 'Create a team',
       notes: 'The POST /authorization/teams endpoint creates a new team given its data\n',
       tags: ['api', 'service', 'post', 'team'],
       plugins: {
@@ -93,7 +95,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('The team ID')
+          id: Joi.string().required().description('The team ID')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -132,7 +134,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('The team ID')
+          id: Joi.string().required().description('The team ID')
         },
         payload: Joi.object().keys({
           name: Joi.string().description('Updated team name'),
@@ -173,7 +175,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('The team ID')
+          id: Joi.string().required().description('The team ID')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -214,10 +216,10 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('The team ID')
+          id: Joi.string().required().description('The team ID')
         },
         payload: {
-          parentId: Joi.number().required().description('The new parent ID')
+          parentId: Joi.string().required().description('The new parent ID')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -259,7 +261,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('The team ID')
+          id: Joi.string().required().description('The team ID')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -296,7 +298,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('Team id')
+          id: Joi.string().required().description('Team id')
         },
         payload: {
           policies: Joi.array().items(Joi.number()).required().description('Policy ids')
@@ -337,7 +339,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('Team id')
+          id: Joi.string().required().description('Team id')
         },
         payload: {
           policies: Joi.array().items(Joi.number()).required().description('Policy ids')
@@ -377,7 +379,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('Team id')
+          id: Joi.string().required().description('Team id')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -413,7 +415,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          teamId: Joi.number().required().description('Team id'),
+          teamId: Joi.string().required().description('Team id'),
           policyId: Joi.number().required().description('Policy id')
         },
         headers: Joi.object({
@@ -451,7 +453,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('The team ID')
+          id: Joi.string().required().description('The team ID')
         },
         payload: Joi.object().keys({
           users: Joi.array().items(Joi.string()).description('User ids')
@@ -492,7 +494,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('The team ID')
+          id: Joi.string().required().description('The team ID')
         },
         payload: Joi.object().keys({
           users: Joi.array().items(Joi.string()).description('User ids')
@@ -532,7 +534,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('The team ID')
+          id: Joi.string().required().description('The team ID')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -568,7 +570,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('The team ID'),
+          id: Joi.string().required().description('The team ID'),
           userId: Joi.string().required().description('The user ID')
         },
         headers: Joi.object({

--- a/service/routes/public/users.js
+++ b/service/routes/public/users.js
@@ -159,7 +159,7 @@ exports.register = function (server, options, next) {
         },
         payload: {
           name: Joi.string().required().description('user name'),
-          teams: Joi.array().required().items(Joi.number())
+          teams: Joi.array().required().items(Joi.string())
         },
         headers: Joi.object({
           'authorization': Joi.any().required()

--- a/service/swagger.js
+++ b/service/swagger.js
@@ -33,7 +33,7 @@ const UserRef = Joi.object({
 })
 
 const Team = Joi.object({
-  id: Joi.number(),
+  id: Joi.string(),
   name: Joi.string(),
   description: Joi.string(),
   path: Joi.string(),
@@ -45,7 +45,7 @@ const Team = Joi.object({
 const TeamList = Joi.array().items(Team)
 
 const TeamRef = Joi.object({
-  id: Joi.number(),
+  id: Joi.string(),
   name: Joi.string()
 })
 

--- a/service/test/endToEnd/teamsTest.js
+++ b/service/test/endToEnd/teamsTest.js
@@ -22,42 +22,42 @@ lab.experiment('Teams - get/list', () => {
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal([
         {
-          id: 1,
+          id: '1',
           name: 'Admins',
           organizationId: 'WONKA',
           description: 'Administrators of the Authorization System',
           path: '1'
         },
         {
-          id: 3,
+          id: '3',
           name: 'Authors',
           organizationId: 'WONKA',
           description: 'Content contributors',
           path: '3'
         },
         {
-          id: 6,
+          id: '6',
           name: 'Company Lawyer',
           organizationId: 'WONKA',
           description: 'Author of legal documents',
           path: '6'
         },
         {
-          id: 4,
+          id: '4',
           name: 'Managers',
           organizationId: 'WONKA',
           description: 'General Line Managers with confidential info',
           path: '4'
         },
         {
-          id: 5,
+          id: '5',
           name: 'Personnel Managers',
           organizationId: 'WONKA',
           description: 'Personnel Line Managers with confidential info',
           path: '5'
         },
         {
-          id: 2,
+          id: '2',
           name: 'Readers',
           organizationId: 'WONKA',
           description: 'General read-only access',
@@ -80,7 +80,7 @@ lab.experiment('Teams - get/list', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({
-        id: 1,
+        id: '1',
         name: 'Admins',
         organizationId: 'WONKA',
         description: 'Administrators of the Authorization System',
@@ -95,7 +95,7 @@ lab.experiment('Teams - get/list', () => {
 })
 
 lab.experiment('Teams - create', () => {
-  lab.test('create new team', (done) => {
+  lab.test('default', (done) => {
     const options = utils.requestOptions({
       method: 'POST',
       url: '/authorization/teams',
@@ -109,21 +109,63 @@ lab.experiment('Teams - create', () => {
       const result = response.result
 
       expect(response.statusCode).to.equal(201)
-      expect(result).to.equal({
-        id: 7,
+      expect(result).to.contain({
         name: 'Team B',
         organizationId: 'WONKA',
         description: 'This is Team B',
-        path: '7',
         users: [],
         policies: []
+      })
+
+      expect(result.path).to.equal(result.id)
+
+      teamOps.deleteTeam({ id: result.id, organizationId: result.organizationId }, done)
+    })
+  })
+
+  lab.test('support specific id', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/teams',
+      payload: {
+        id: 'test_fixed_id',
+        name: 'Team B',
+        description: 'This is Team B'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result).to.contain({
+        id: 'test_fixed_id',
+        path: 'test_fixed_id'
       })
 
       teamOps.deleteTeam({ id: result.id, organizationId: result.organizationId }, done)
     })
   })
 
-  lab.test('create new team should return a 400 Bad Request when not providing name or description', (done) => {
+  lab.test('validates specific id format', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/teams',
+      payload: {
+        id: 'invalid-id',
+        name: 'Team B',
+        description: 'This is Team B'
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      expect(response.result.validation.keys).to.include('id')
+      done()
+    })
+  })
+
+  lab.test('should return a 400 Bad Request when not providing name or description', (done) => {
     const options = utils.requestOptions({
       method: 'POST',
       url: '/authorization/teams',
@@ -168,7 +210,7 @@ lab.experiment('Teams - update', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({
-        id: 1,
+        id: '1',
         name: 'Team C',
         description: 'Administrators of the Authorization System',
         path: '1',
@@ -177,7 +219,7 @@ lab.experiment('Teams - update', () => {
         policies: [{ id: 1, name: 'Director', version: '0.1' }]
       })
 
-      teamOps.updateTeam({ id: 1, name: 'Admins', organizationId: result.organizationId }, done)
+      teamOps.updateTeam({ id: '1', name: 'Admins', organizationId: result.organizationId }, done)
     })
   })
 
@@ -195,7 +237,7 @@ lab.experiment('Teams - update', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({
-        id: 1,
+        id: '1',
         name: 'Admins',
         description: 'Team B is now Team C',
         path: '1',
@@ -204,13 +246,13 @@ lab.experiment('Teams - update', () => {
         policies: [{ id: 1, name: 'Director', version: '0.1' }]
       })
 
-      teamOps.updateTeam({ id: 1, description: 'Administrators of the Authorization System', organizationId: result.organizationId }, done)
+      teamOps.updateTeam({ id: '1', description: 'Administrators of the Authorization System', organizationId: result.organizationId }, done)
     })
   })
 
   lab.test('update team', (done) => {
     const teamOriginalData = {
-      id: 1,
+      id: '1',
       name: 'Admins',
       organizationId: 'WONKA',
       description: 'Administrators of the Authorization System'
@@ -229,7 +271,7 @@ lab.experiment('Teams - update', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({
-        id: 1,
+        id: '1',
         name: 'Team C',
         organizationId: 'WONKA',
         description: 'Team B is now Team C',
@@ -280,7 +322,7 @@ lab.experiment('Teams - manage users', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({
-        id: 2,
+        id: '2',
         name: 'Readers',
         description: 'General read-only access',
         path: '2',
@@ -293,7 +335,7 @@ lab.experiment('Teams - manage users', () => {
         policies: []
       })
 
-      teamOps.replaceUsersInTeam({ id: 2, users: ['CharlieId', 'VerucaId'], organizationId: 'WONKA' }, done)
+      teamOps.replaceUsersInTeam({ id: '2', users: ['CharlieId', 'VerucaId'], organizationId: 'WONKA' }, done)
     })
   })
 
@@ -311,7 +353,7 @@ lab.experiment('Teams - manage users', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({
-        id: 2,
+        id: '2',
         name: 'Readers',
         description: 'General read-only access',
         path: '2',
@@ -320,7 +362,7 @@ lab.experiment('Teams - manage users', () => {
         policies: []
       })
 
-      teamOps.replaceUsersInTeam({ id: 2, users: ['CharlieId', 'VerucaId'], organizationId: 'WONKA' }, done)
+      teamOps.replaceUsersInTeam({ id: '2', users: ['CharlieId', 'VerucaId'], organizationId: 'WONKA' }, done)
     })
   })
 
@@ -336,7 +378,7 @@ lab.experiment('Teams - manage users', () => {
       expect(response.statusCode).to.equal(204)
       expect(result).to.not.exist()
 
-      teamOps.replaceUsersInTeam({ id: 2, users: ['CharlieId', 'VerucaId'], organizationId: 'WONKA' }, done)
+      teamOps.replaceUsersInTeam({ id: '2', users: ['CharlieId', 'VerucaId'], organizationId: 'WONKA' }, done)
     })
   })
 
@@ -352,7 +394,7 @@ lab.experiment('Teams - manage users', () => {
       expect(response.statusCode).to.equal(204)
       expect(result).to.not.exist()
 
-      teamOps.replaceUsersInTeam({ id: 2, users: ['CharlieId', 'VerucaId'], organizationId: 'WONKA' }, done)
+      teamOps.replaceUsersInTeam({ id: '2', users: ['CharlieId', 'VerucaId'], organizationId: 'WONKA' }, done)
     })
   })
 })
@@ -363,7 +405,7 @@ lab.experiment('Teams - nest/un-nest', () => {
       method: 'PUT',
       url: '/authorization/teams/2/nest',
       payload: {
-        parentId: 3
+        parentId: '3'
       }
     })
 
@@ -372,7 +414,7 @@ lab.experiment('Teams - nest/un-nest', () => {
 
       expect(response.statusCode).to.equal(201)
       expect(result).to.equal({
-        id: 2,
+        id: '2',
         name: 'Readers',
         description: 'General read-only access',
         path: '3.2',
@@ -389,7 +431,7 @@ lab.experiment('Teams - nest/un-nest', () => {
   })
 
   lab.test('Un-nest team should update the team path', (done) => {
-    teamOps.moveTeam({ id: 2, parentId: 3, organizationId: 'WONKA' }, (err, res) => {
+    teamOps.moveTeam({ id: '2', parentId: '3', organizationId: 'WONKA' }, (err, res) => {
       expect(err).to.not.exist()
 
       const options = utils.requestOptions({
@@ -402,7 +444,7 @@ lab.experiment('Teams - nest/un-nest', () => {
 
         expect(response.statusCode).to.equal(201)
         expect(result).to.equal({
-          id: 2,
+          id: '2',
           name: 'Readers',
           description: 'General read-only access',
           path: '2',
@@ -435,7 +477,7 @@ lab.experiment('Teams - manage policies', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({
-        id: 1,
+        id: '1',
         name: 'Admins',
         description: 'Administrators of the Authorization System',
         path: '1',
@@ -465,7 +507,7 @@ lab.experiment('Teams - manage policies', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({
-        id: 1,
+        id: '1',
         name: 'Admins',
         description: 'Administrators of the Authorization System',
         path: '1',
@@ -497,7 +539,7 @@ lab.experiment('Teams - manage policies', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({
-        id: 1,
+        id: '1',
         name: 'Admins',
         description: 'Administrators of the Authorization System',
         path: '1',
@@ -519,7 +561,7 @@ lab.experiment('Teams - manage policies', () => {
     server.inject(options, (response) => {
       expect(response.statusCode).to.equal(204)
 
-      teamOps.replaceTeamPolicies({ id: 1, policies: [1], organizationId: 'WONKA' }, done)
+      teamOps.replaceTeamPolicies({ id: '1', policies: [1], organizationId: 'WONKA' }, done)
     })
   })
 
@@ -580,7 +622,7 @@ lab.experiment('Teams - manage policies', () => {
     server.inject(options, (response) => {
       expect(response.statusCode).to.equal(204)
 
-      teamOps.replaceTeamPolicies({ id: 1, policies: [1], organizationId: 'WONKA' }, done)
+      teamOps.replaceTeamPolicies({ id: '1', policies: [1], organizationId: 'WONKA' }, done)
     })
   })
 })
@@ -655,7 +697,7 @@ lab.experiment('Teams - checking org_id scoping', () => {
       method: 'PUT',
       url: `/authorization/teams/${teamId}/nest`,
       payload: {
-        parentId: 1
+        parentId: '1'
       }
     })
 

--- a/service/test/endToEnd/usersTest.js
+++ b/service/test/endToEnd/usersTest.js
@@ -49,7 +49,7 @@ lab.experiment('Users: read - delete - update', () => {
         policies: [],
         teams: [
           {
-            id: 1,
+            id: '1',
             name: 'Admins'
           }
         ]
@@ -88,7 +88,7 @@ lab.experiment('Users: read - delete - update', () => {
       url: '/authorization/users/ModifyId',
       payload: {
         name: 'Modify you',
-        teams: [3, 4]
+        teams: ['3', '4']
       }
     })
 
@@ -101,8 +101,8 @@ lab.experiment('Users: read - delete - update', () => {
         name: 'Modify you',
         organizationId: 'WONKA',
         teams: [
-          { id: 3, name: 'Authors' },
-          { id: 4, name: 'Managers' }
+          { id: '3', name: 'Authors' },
+          { id: '4', name: 'Managers' }
         ],
         policies: []
       })

--- a/service/test/lib/integration/teamOpsTest.js
+++ b/service/test/lib/integration/teamOpsTest.js
@@ -307,7 +307,7 @@ lab.experiment('TeamOps', () => {
           teamOps.readTeam({ id: childId, organizationId: 'WONKA' }, (err) => {
             expect(err).to.exist()
             expect(err.isBoom).to.be.true()
-            expect(err.message).to.match(/Team with id [\d]+ could not be found/)
+            expect(err.message).to.match(/Team with id [a-zA-Z0-9_]+ could not be found/)
             done()
           })
         })

--- a/service/test/lib/integration/userOpsTest.js
+++ b/service/test/lib/integration/userOpsTest.js
@@ -66,7 +66,7 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('update a user', (done) => {
-    const expected = { id: 'AugustusId', name: 'Augustus Gloop', organizationId: 'WONKA', teams: [{ id: 4, name: 'Managers' }], policies: [] }
+    const expected = { id: 'AugustusId', name: 'Augustus Gloop', organizationId: 'WONKA', teams: [{ id: '4', name: 'Managers' }], policies: [] }
     const data = {
       id: 'AugustusId',
       organizationId: 'WONKA',
@@ -85,7 +85,7 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('read a specific user', (done) => {
-    const expected = { id: 'VerucaId', name: 'Veruca Salt', organizationId: 'WONKA', teams: [{ id: 3, name: 'Authors' }, { id: 2, name: 'Readers' }], policies: [{ id: 2, version: '0.1', name: 'Accountant' }] }
+    const expected = { id: 'VerucaId', name: 'Veruca Salt', organizationId: 'WONKA', teams: [{ id: '3', name: 'Authors' }, { id: '2', name: 'Readers' }], policies: [{ id: 2, version: '0.1', name: 'Accountant' }] }
     userOps.readUser({ id: 'VerucaId', organizationId: 'WONKA' }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()


### PR DESCRIPTION
Fixes #247 

I have a question: how should the app behave if on creation is specified an id that already exists on the db?
At the moment we just return 500 bad implementation due to the db constraint, my feeling is that we should manage the error and return the proper status code and message.
@p16 how did you implement this on the users?

@feugy thoughts?