### PR TITLE
add users count per team

### DIFF
--- a/service/lib/mapping.js
+++ b/service/lib/mapping.js
@@ -63,6 +63,19 @@ function mapTeam (row) {
   }
 }
 
+function mapTeamList (row) {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    path: row.path,
+    organizationId: row.org_id,
+    membersCount: row.members
+  }
+}
+
+mapTeam.list = mapTeamList
+
 function mapTeamSimple (row) {
   return {
     id: row.id,

--- a/service/lib/ops/teamOps.js
+++ b/service/lib/ops/teamOps.js
@@ -280,15 +280,17 @@ var teamOps = {
     const { organizationId } = params
 
     const sqlQuery = SQL`
-      SELECT  *
+      SELECT teams.id, teams.name, teams.description, teams.path, teams.org_id, COUNT(team_members.team_id) AS members
       FROM teams
+      LEFT JOIN team_members ON team_members.team_id = teams.id
       WHERE org_id = ${organizationId}
+      GROUP BY teams.id, teams.name, teams.description, teams.path, teams.org_id
       ORDER BY UPPER(name)
     `
     db.query(sqlQuery, function (err, result) {
       if (err) return cb(err)
 
-      return cb(null, result.rows.map(mapping.team))
+      return cb(null, result.rows.map(mapping.team.list))
     })
   },
 

--- a/service/swagger.js
+++ b/service/swagger.js
@@ -39,7 +39,8 @@ const Team = Joi.object({
   path: Joi.string(),
   users: Joi.array().items(UserRef),
   policies: Joi.array().items(PolicyRef),
-  organizationId: Joi.string()
+  organizationId: Joi.string(),
+  membersCount: Joi.number()
 })
 
 const TeamList = Joi.array().items(Team)

--- a/service/test/endToEnd/teamsTest.js
+++ b/service/test/endToEnd/teamsTest.js
@@ -33,42 +33,48 @@ lab.experiment('Teams - get/list', () => {
           name: 'Admins',
           organizationId: 'WONKA',
           description: 'Administrators of the Authorization System',
-          path: '1'
+          path: '1',
+          membersCount: '1'
         },
         {
           id: '3',
           name: 'Authors',
           organizationId: 'WONKA',
           description: 'Content contributors',
-          path: '3'
+          path: '3',
+          membersCount: '1'
         },
         {
           id: '6',
           name: 'Company Lawyer',
           organizationId: 'WONKA',
           description: 'Author of legal documents',
-          path: '6'
+          path: '6',
+          membersCount: '0'
         },
         {
           id: '4',
           name: 'Managers',
           organizationId: 'WONKA',
           description: 'General Line Managers with confidential info',
-          path: '4'
+          path: '4',
+          membersCount: '1'
         },
         {
           id: '5',
           name: 'Personnel Managers',
           organizationId: 'WONKA',
           description: 'Personnel Line Managers with confidential info',
-          path: '5'
+          path: '5',
+          membersCount: '1'
         },
         {
           id: '2',
           name: 'Readers',
           organizationId: 'WONKA',
           description: 'General read-only access',
-          path: '2'
+          path: '2',
+          membersCount: '2'
         }
       ])
 


### PR DESCRIPTION
Implements https://github.com/nearform/labs-authorization/issues/257

The team count counts the users in the team but not in subteams.