### PR TITLE
Remove left over "teams" param in user update endpoint

### DIFF
--- a/service/routes/public/users.js
+++ b/service/routes/public/users.js
@@ -142,13 +142,12 @@ exports.register = function (server, options, next) {
     handler: function (request, reply) {
       const { organizationId } = request.udaru
       const id = request.params.id
-      const { name, teams } = request.payload
+      const { name } = request.payload
 
       const params = {
         id,
         organizationId,
-        name,
-        teams
+        name
       }
       userOps.updateUser(params, reply)
     },
@@ -158,8 +157,7 @@ exports.register = function (server, options, next) {
           id: Joi.string().required().description('user id')
         },
         payload: {
-          name: Joi.string().required().description('user name'),
-          teams: Joi.array().required().items(Joi.string())
+          name: Joi.string().required().description('user name')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()

--- a/service/test/endToEnd/usersTest.js
+++ b/service/test/endToEnd/usersTest.js
@@ -94,8 +94,7 @@ lab.experiment('Users: read - delete - update', () => {
       method: 'PUT',
       url: '/authorization/users/ModifyId',
       payload: {
-        name: 'Modify you',
-        teams: ['3', '4']
+        name: 'Modify you'
       }
     })
 
@@ -107,14 +106,11 @@ lab.experiment('Users: read - delete - update', () => {
         id: 'ModifyId',
         name: 'Modify you',
         organizationId: 'WONKA',
-        teams: [
-          { id: '3', name: 'Authors' },
-          { id: '4', name: 'Managers' }
-        ],
+        teams: [],
         policies: []
       })
 
-      userOps.updateUser({ name: 'Modify Me', id: 'ModifyId', organizationId: 'WONKA', teams: [] }, done)
+      userOps.updateUser({ name: 'Modify Me', id: 'ModifyId', organizationId: 'WONKA' }, done)
     })
   })
 })

--- a/service/test/lib/integration/userOpsTest.js
+++ b/service/test/lib/integration/userOpsTest.js
@@ -98,29 +98,24 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('update a user', (done) => {
-    let managersTeam = u.findPick(wonkaTeams, {name: 'Managers'}, ['id', 'name'])
-    const expected = {
-      id: 'AugustusId',
-      name: 'Augustus Gloop',
-      organizationId: 'WONKA',
-      teams: [managersTeam],
-      policies: []
-    }
     const data = {
       id: 'AugustusId',
       organizationId: 'WONKA',
-      name: 'Augustus Gloop',
-      teams: [managersTeam.id]
+      name: 'Augustus Gloop new'
     }
 
     userOps.updateUser(data, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
-      expect(result).to.equal(expected)
+      expect(result).to.equal({
+        id: 'AugustusId',
+        name: 'Augustus Gloop new',
+        organizationId: 'WONKA',
+        teams: [{ id: '1', name: 'Admins' }],
+        policies: []
+      })
 
-      let pManagersTeam = _.find(wonkaTeams, {name: 'Personnel Managers'})
-      data.teams = [managersTeam.id, pManagersTeam.id]
-      userOps.updateUser(data, done)
+      userOps.updateUser({ id: 'AugustusId', organizationId: 'WONKA', name: 'Augustus Gloop new' }, done)
     })
   })
 

--- a/service/test/routes/public/usersTest.js
+++ b/service/test/routes/public/usersTest.js
@@ -120,8 +120,7 @@ lab.experiment('Users', () => {
       method: 'PUT',
       url: '/authorization/users/MyId',
       payload: {
-        name: 'Joe',
-        teams: []
+        name: 'Joe'
       }
     })
 

--- a/service/test/utils.js
+++ b/service/test/utils.js
@@ -1,6 +1,8 @@
 'use strict'
 
 let _ = require('lodash')
+let db = require('./../lib/db')
+let SQL = require('./../lib/db/SQL')
 
 /**
  * Merge the authorization default header with the provided options
@@ -23,7 +25,14 @@ function findPick (arr, search, fields) {
   return _.pick(_.find(arr, search), fields)
 }
 
+function deleteUserFromAllTeams (id, cb) {
+  const sqlQuery = SQL`DELETE FROM team_members WHERE user_id = ${id}`
+
+  db.query(sqlQuery, cb)
+}
+
 module.exports = {
   requestOptions,
-  findPick
+  findPick,
+  deleteUserFromAllTeams
 }


### PR DESCRIPTION
This PR removes the `teams` param from `PUT /users/{id}` endpoint.

The idea is that now that we have

```
PUT /teams/{id}/users
POST /teams/{id}/users
DELETE /teams/{id}/users
DELETE /teams/{id}/users/{userId}
```

we should work on teams members from those endpoints and not from the user update one.

/cc @feugy @marcopiraccini 

Ref. issue #275 