### PR TITLE
Issue 258 paginated team list users

### DIFF
--- a/service/lib/mapping.js
+++ b/service/lib/mapping.js
@@ -70,7 +70,7 @@ function mapTeamList (row) {
     description: row.description,
     path: row.path,
     organizationId: row.org_id,
-    membersCount: row.members
+    usersCount: parseInt(row.users_count)
   }
 }
 

--- a/service/lib/ops/teamOps.js
+++ b/service/lib/ops/teamOps.js
@@ -376,6 +376,7 @@ var teamOps = {
       db.query(sql, function (err, result) {
         if (err) return next(Boom.badImplementation(err))
 
+        team.usersCount = result.rowCount
         team.users = result.rows.map(mapping.user.simple)
         next()
       })

--- a/service/lib/ops/teamOps.js
+++ b/service/lib/ops/teamOps.js
@@ -272,6 +272,67 @@ function checkTeamExists (job, next) {
   })
 }
 
+function loadTeams (job, next) {
+  const { id, organizationId } = job
+  const sql = SQL`
+    SELECT *
+    FROM teams
+    WHERE id = ${id}
+    AND org_id = ${organizationId}
+  `
+  db.query(sql, (err, result) => {
+    if (err) return next(Boom.badImplementation(err))
+    if (result.rowCount === 0) return next(Boom.notFound(`Team with id ${id} could not be found`))
+
+    job.team = mapping.team(result.rows[0])
+
+    job.team.users = []
+    job.team.policies = []
+    next()
+  })
+}
+
+function loadTeamUsers (job, next) {
+  const { id, offset, limit } = job
+  const sql = SQL`
+    SELECT users.id, users.name
+    FROM team_members mem, users
+    WHERE mem.team_id = ${id}
+    AND mem.user_id = users.id
+    ORDER BY UPPER(users.name)
+  `
+  if (limit) {
+    sql.append(SQL` LIMIT ${limit}`)
+  }
+  if (offset) {
+    sql.append(SQL` OFFSET ${offset}`)
+  }
+  db.query(sql, function (err, result) {
+    if (err) return next(Boom.badImplementation(err))
+
+    job.team.usersCount = result.rowCount
+    job.team.users = result.rows.map(mapping.user.simple)
+    next()
+  })
+}
+
+function loadTeamPolicies (job, next) {
+  const { id } = job
+  const sql = SQL`
+    SELECT pol.id, pol.name, pol.version
+    FROM team_policies tpol, policies pol
+    WHERE tpol.team_id = ${id}
+    AND tpol.policy_id = pol.id
+    ORDER BY UPPER(pol.name)
+  `
+  db.query(sql, function (err, result) {
+    if (err) return next(Boom.badImplementation(err))
+
+    job.team.policies = result.rows.map(mapping.policy.simple)
+    next()
+  })
+}
+
 var teamOps = {
 
   /**
@@ -336,72 +397,51 @@ var teamOps = {
   },
 
   /**
+   * Fetch the users data from a team
+   *
+   * @param  {params}   params { id, page, limit }
+   * @param  {Function} cb
+   */
+  readTeamUsers: function readTeamUsers ({ id, page, limit }, cb) {
+    const offset = (page < 1 ? 1 : page) * limit - limit
+    const job = {
+      id: id,
+      offset: offset,
+      limit: limit < 0 ? 0 : limit,
+      team: {}
+    }
+
+    loadTeamUsers(job, (err) => {
+      if (err) return cb(err)
+
+      return cb(null, job.team.users)
+    })
+  },
+
+  /**
    * Fetch specific team data
    *
    * @param  {params}   params { id, organizationId }
    * @param  {Function} cb
    */
   readTeam: function readTeam ({ id, organizationId }, cb) {
-    const tasks = []
-    let team
+    const job = {
+      team: {}
+    }
 
-    tasks.push((next) => {
-      const sql = SQL`
-        SELECT *
-        FROM teams
-        WHERE id = ${id}
-        AND org_id = ${organizationId}
-      `
-
-      db.query(sql, (err, result) => {
-        if (err) return next(Boom.badImplementation(err))
-        if (result.rowCount === 0) return next(Boom.notFound(`Team with id ${id} could not be found`))
-
-        team = mapping.team(result.rows[0])
-
-        team.users = []
-        team.policies = []
+    async.applyEachSeries([
+      (job, next) => {
+        job.id = id
+        job.organizationId = organizationId
         next()
-      })
-    })
-
-    tasks.push((next) => {
-      const sql = SQL`
-        SELECT users.id, users.name
-        FROM team_members mem, users
-        WHERE mem.team_id = ${id}
-        AND mem.user_id = users.id
-        ORDER BY UPPER(users.name)
-      `
-      db.query(sql, function (err, result) {
-        if (err) return next(Boom.badImplementation(err))
-
-        team.usersCount = result.rowCount
-        team.users = result.rows.map(mapping.user.simple)
-        next()
-      })
-    })
-
-    tasks.push((next) => {
-      const sql = SQL`
-        SELECT pol.id, pol.name, pol.version
-        FROM team_policies tpol, policies pol
-        WHERE tpol.team_id = ${id}
-        AND tpol.policy_id = pol.id
-        ORDER BY UPPER(pol.name)
-      `
-      db.query(sql, function (err, result) {
-        if (err) return next(Boom.badImplementation(err))
-
-        team.policies = result.rows.map(mapping.policy.simple)
-        next()
-      })
-    })
-
-    async.series(tasks, (err) => {
+      },
+      loadTeams,
+      loadTeamUsers,
+      loadTeamPolicies
+    ], job, (err) => {
       if (err) return cb(err)
 
-      return cb(null, team)
+      return cb(null, job.team)
     })
   },
 

--- a/service/lib/ops/teamOps.js
+++ b/service/lib/ops/teamOps.js
@@ -284,7 +284,7 @@ var teamOps = {
     const { organizationId } = params
 
     const sqlQuery = SQL`
-      SELECT teams.id, teams.name, teams.description, teams.path, teams.org_id, COUNT(team_members.team_id) AS members
+      SELECT teams.id, teams.name, teams.description, teams.path, teams.org_id, COUNT(team_members.team_id) AS users_count
       FROM teams
       LEFT JOIN team_members ON team_members.team_id = teams.id
       WHERE org_id = ${organizationId}

--- a/service/routes/public/teams.js
+++ b/service/routes/public/teams.js
@@ -449,8 +449,8 @@ exports.register = function (server, options, next) {
           id: Joi.string().required().description('The team ID')
         },
         query: {
-          page: Joi.string().required().description('Page number, starts from 1'),
-          limit: Joi.string().required().description('Users per page')
+          page: Joi.number().integer().positive().required().description('Page number, starts from 1'),
+          limit: Joi.number().integer().positive().required().description('Users per page')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()

--- a/service/routes/public/teams.js
+++ b/service/routes/public/teams.js
@@ -457,7 +457,7 @@ exports.register = function (server, options, next) {
         }).unknown()
       },
       description: 'Fetch team users given its identifier',
-      notes: 'The GET /authorization/teams/{id}/users endpoint returns the users from a team. The results are paginated. Page numbers start from 1. \n',
+      notes: 'The GET /authorization/teams/{id}/users endpoint returns the users from a team and metadata related to pagination. The results are paginated. Page numbers start from 1. \n',
       tags: ['api', 'service', 'get', 'team', 'users'],
       plugins: {
         auth: {
@@ -465,7 +465,7 @@ exports.register = function (server, options, next) {
           getParams: (request) => ({ teamId: request.params.id })
         }
       },
-      response: {schema: swagger.UserList}
+      response: {schema: swagger.MetadataUserList}
     }
   })
 

--- a/service/routes/public/teams.js
+++ b/service/routes/public/teams.js
@@ -435,6 +435,41 @@ exports.register = function (server, options, next) {
   })
 
   server.route({
+    method: 'GET',
+    path: '/authorization/teams/{id}/users',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { page, limit } = request.query
+
+      teamOps.readTeamUsers({ id, page, limit }, reply)
+    },
+    config: {
+      validate: {
+        params: {
+          id: Joi.string().required().description('The team ID')
+        },
+        query: {
+          page: Joi.string().required().description('Page number, starts from 1'),
+          limit: Joi.string().required().description('Users per page')
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
+      },
+      description: 'Fetch team users given its identifier',
+      notes: 'The GET /authorization/teams/{id}/users endpoint returns the users from a team. The results are paginated. Page numbers start from 1. \n',
+      tags: ['api', 'service', 'get', 'team', 'users'],
+      plugins: {
+        auth: {
+          action: Action.ReadTeam,
+          getParams: (request) => ({ teamId: request.params.id })
+        }
+      },
+      response: {schema: swagger.UserList}
+    }
+  })
+
+  server.route({
     method: 'PUT',
     path: '/authorization/teams/{id}/users',
     handler: function (request, reply) {
@@ -463,7 +498,7 @@ exports.register = function (server, options, next) {
         }).unknown()
       },
       description: 'Add team members',
-      notes: 'The PUT /authorization/teams/{id}/users endpoint add one or more team members',
+      notes: 'The PUT /authorization/teams/{id}/users endpoint adds one or more team members',
       tags: ['api', 'service', 'put', 'team', 'users'],
       plugins: {
         auth: {
@@ -504,7 +539,7 @@ exports.register = function (server, options, next) {
         }).unknown()
       },
       description: 'Replace team members with the given ones',
-      notes: 'The POST /authorization/teams/{id}/users endpoint replace all team members',
+      notes: 'The POST /authorization/teams/{id}/users endpoint replaces all team members',
       tags: ['api', 'service', 'post', 'team', 'users'],
       plugins: {
         auth: {

--- a/service/swagger.js
+++ b/service/swagger.js
@@ -60,6 +60,14 @@ const User = Joi.object({
 
 const UserList = Joi.array().items(User)
 
+const MetadataUserList = Joi.object({
+  currentPage: Joi.number().integer(),
+  pageSize: Joi.number().integer(),
+  totalPages: Joi.number().integer(),
+  totalUsersCount: Joi.number().integer(),
+  users: Joi.array().items(User)
+})
+
 const Organization = Joi.object({
   id: Joi.string(),
   name: Joi.string(),
@@ -74,6 +82,7 @@ const OrganizationList = Joi.array().items(Organization)
 
 module.exports = {
   UserList: UserList,
+  MetadataUserList: MetadataUserList,
   User: User,
   TeamList: TeamList,
   Team: Team,

--- a/service/swagger.js
+++ b/service/swagger.js
@@ -40,7 +40,7 @@ const Team = Joi.object({
   users: Joi.array().items(UserRef),
   policies: Joi.array().items(PolicyRef),
   organizationId: Joi.string(),
-  membersCount: Joi.number()
+  usersCount: Joi.number()
 })
 
 const TeamList = Joi.array().items(Team)

--- a/service/test/endToEnd/teamsTest.js
+++ b/service/test/endToEnd/teamsTest.js
@@ -109,20 +109,10 @@ lab.experiment('Teams - get/list', () => {
     teamOps.createTeam(teamData, (err, team) => {
       if (err) return done(err)
 
-      const options = utils.requestOptions({
-        method: 'PUT',
-        url: `/authorization/teams/${team.id}/users`,
-        payload: {
-          users: ['CharlieId', 'MikeId']
-        }
-      })
+      teamOps.addUsersToTeam({id: team.id, organizationId: team.organizationId, users: ['CharlieId', 'MikeId']}, (err, team) => {
+        if (err) return done(err)
 
-      server.inject(options, (response) => {
-        const result = response.result
-
-        expect(response.statusCode).to.equal(200)
-        expect(result.id).to.equal(team.id)
-        expect(result.users).to.equal([
+        expect(team.users).to.equal([
           { id: 'CharlieId', name: 'Charlie Bucket' },
           { id: 'MikeId', name: 'Mike Teavee' }
         ])

--- a/service/test/endToEnd/teamsTest.js
+++ b/service/test/endToEnd/teamsTest.js
@@ -95,6 +95,8 @@ lab.experiment('Teams - get/list', () => {
         const result = response.result
 
         expect(response.statusCode).to.equal(200)
+        expect(result.usersCount).to.exist()
+        expect(result.usersCount).to.equal(0)
         expect(result.id).to.equal(team.id)
         expect(result.name).to.equal(team.name)
 
@@ -454,6 +456,7 @@ lab.experiment('Teams - manage users', () => {
           description: 'This is a test team',
           path: team.path,
           organizationId: 'WONKA',
+          usersCount: 3,
           users: [
             { id: 'CharlieId', name: 'Charlie Bucket' },
             { id: 'MikeId', name: 'Mike Teavee' },

--- a/service/test/endToEnd/teamsTest.js
+++ b/service/test/endToEnd/teamsTest.js
@@ -34,7 +34,7 @@ lab.experiment('Teams - get/list', () => {
           organizationId: 'WONKA',
           description: 'Administrators of the Authorization System',
           path: '1',
-          membersCount: '1'
+          usersCount: 1
         },
         {
           id: '3',
@@ -42,7 +42,7 @@ lab.experiment('Teams - get/list', () => {
           organizationId: 'WONKA',
           description: 'Content contributors',
           path: '3',
-          membersCount: '1'
+          usersCount: 1
         },
         {
           id: '6',
@@ -50,7 +50,7 @@ lab.experiment('Teams - get/list', () => {
           organizationId: 'WONKA',
           description: 'Author of legal documents',
           path: '6',
-          membersCount: '0'
+          usersCount: 0
         },
         {
           id: '4',
@@ -58,7 +58,7 @@ lab.experiment('Teams - get/list', () => {
           organizationId: 'WONKA',
           description: 'General Line Managers with confidential info',
           path: '4',
-          membersCount: '1'
+          usersCount: 1
         },
         {
           id: '5',
@@ -66,7 +66,7 @@ lab.experiment('Teams - get/list', () => {
           organizationId: 'WONKA',
           description: 'Personnel Line Managers with confidential info',
           path: '5',
-          membersCount: '1'
+          usersCount: 1
         },
         {
           id: '2',
@@ -74,7 +74,7 @@ lab.experiment('Teams - get/list', () => {
           organizationId: 'WONKA',
           description: 'General read-only access',
           path: '2',
-          membersCount: '2'
+          usersCount: 2
         }
       ])
 

--- a/service/test/lib/integration/teamOpsTest.js
+++ b/service/test/lib/integration/teamOpsTest.js
@@ -162,6 +162,10 @@ lab.experiment('TeamOps', () => {
       expect(result).to.exist()
       expect(result.name).to.equal(testTeam.name)
       expect(result.description).to.equal(testTeam.description)
+      expect(result.usersCount).to.equal(1)
+      expect(result.usersCount).to.equal(result.users.length)
+      expect(result.users.length).to.equal(1)
+      expect(result.policies.length).to.equal(1)
 
       done()
     })

--- a/service/test/lib/integration/teamOpsTest.js
+++ b/service/test/lib/integration/teamOpsTest.js
@@ -154,16 +154,17 @@ lab.experiment('TeamOps', () => {
     })
   })
 
+  // TODO: Needs review
   lab.test('read a specific team', (done) => {
-    teamOps.readTeam({ id: testTeam.id, organizationId: 'WONKA' }, (err, result) => {
+    teamOps.readTeam({ id: '2', organizationId: 'WONKA' }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
-      expect(result.name).to.equal(testTeam.name)
-      expect(result.description).to.equal(testTeam.description)
-      expect(result.usersCount).to.equal(1)
+      expect(result.name).to.equal('Readers')
+      expect(result.description).to.equal('General read-only access')
+      expect(result.usersCount).to.equal(2)
       expect(result.usersCount).to.equal(result.users.length)
-      expect(result.users.length).to.equal(1)
-      expect(result.policies.length).to.equal(1)
+      expect(result.users.length).to.equal(2)
+      expect(result.policies.length).to.equal(0)
 
       done()
     })
@@ -173,8 +174,12 @@ lab.experiment('TeamOps', () => {
     teamOps.readTeamUsers({ id: '2' }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
-      expect(result.length).to.equal(2)
-      expect(result).to.equal([
+      expect(result.currentPage).to.equal(1)
+      expect(result.pageSize).to.equal(2)
+      expect(result.totalPages).to.equal(1)
+      expect(result.totalUsersCount).to.equal(2)
+      expect(result.users.length).to.equal(2)
+      expect(result.users).to.equal([
         { id: 'CharlieId', name: 'Charlie Bucket' },
         { id: 'VerucaId', name: 'Veruca Salt' }
       ])
@@ -187,8 +192,12 @@ lab.experiment('TeamOps', () => {
     teamOps.readTeamUsers({ id: '2', page: 2, limit: 1 }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
-      expect(result.length).to.equal(1)
-      expect(result).to.equal([
+      expect(result.currentPage).to.equal(2)
+      expect(result.pageSize).to.equal(1)
+      expect(result.totalPages).to.equal(2)
+      expect(result.totalUsersCount).to.equal(2)
+      expect(result.users.length).to.equal(1)
+      expect(result.users).to.equal([
         { id: 'VerucaId', name: 'Veruca Salt' }
       ])
 

--- a/service/test/lib/integration/teamOpsTest.js
+++ b/service/test/lib/integration/teamOpsTest.js
@@ -155,9 +155,7 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('read a specific team', (done) => {
-
     teamOps.readTeam({ id: testTeam.id, organizationId: 'WONKA' }, (err, result) => {
-
       expect(err).to.not.exist()
       expect(result).to.exist()
       expect(result.name).to.equal(testTeam.name)
@@ -166,6 +164,43 @@ lab.experiment('TeamOps', () => {
       expect(result.usersCount).to.equal(result.users.length)
       expect(result.users.length).to.equal(1)
       expect(result.policies.length).to.equal(1)
+
+      done()
+    })
+  })
+
+  lab.test('read users from a specific team', (done) => {
+    teamOps.readTeamUsers({ id: '2' }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.exist()
+      expect(result.length).to.equal(2)
+      expect(result).to.equal([
+        { id: 'CharlieId', name: 'Charlie Bucket' },
+        { id: 'VerucaId', name: 'Veruca Salt' }
+      ])
+
+      done()
+    })
+  })
+
+  lab.test('paginated read users from a specific team', (done) => {
+    teamOps.readTeamUsers({ id: '2', page: 2, limit: 1 }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.exist()
+      expect(result.length).to.equal(1)
+      expect(result).to.equal([
+        { id: 'VerucaId', name: 'Veruca Salt' }
+      ])
+
+      done()
+    })
+  })
+
+  lab.test('read users from a specific team, show from the 2nd user', (done) => {
+    teamOps.readTeamUsers({ id: '1' }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.exist()
+      expect(result.length).to.equal(1)
 
       done()
     })

--- a/service/test/lib/integration/teamOpsTest.js
+++ b/service/test/lib/integration/teamOpsTest.js
@@ -196,16 +196,6 @@ lab.experiment('TeamOps', () => {
     })
   })
 
-  lab.test('read users from a specific team, show from the 2nd user', (done) => {
-    teamOps.readTeamUsers({ id: '1' }, (err, result) => {
-      expect(err).to.not.exist()
-      expect(result).to.exist()
-      expect(result.length).to.equal(1)
-
-      done()
-    })
-  })
-
   lab.test('creating a team should create a default admin policy', (done) => {
 
     policyOps.listByOrganization({organizationId: 'WONKA'}, (err, policies) => {


### PR DESCRIPTION
3 commits:
- return user count as number on the teams endpoint,
- return user count also on the get team endpoint,
- paginated users from team. Returns as metadata beside users also  currentPage, pageSize, totalPages, totalUsersCount