### PR TITLE
Custom test framework

### DIFF
--- a/service/test/endToEnd/authorization/usersTest.js
+++ b/service/test/endToEnd/authorization/usersTest.js
@@ -504,35 +504,16 @@ lab.experiment('Routes Authorizations', () => {
         }
       }
 
-      lab.before((done) => {
-        userOps.createUser({ name: 'caller', organizationId }, (err, caller) => {
-          if (err) return done(err)
-          callerId = caller.id
-
-          teamOps.createTeam({ name: 'called team', organizationId }, (err, team) => {
-            if (err) return done(err)
-            calledTeamId = team.id
-
-            const policyCreateData = Policy()
-
-            policyOps.createPolicy(policyCreateData, (err, policy) => {
-              if (err) return done(err)
-              policyId = policy.id
-
-              userOps.addUserPolicies({ id: callerId, organizationId, policies: [policyId] }, done)
-            })
-          })
-        })
-      })
-
-      lab.after((done) => {
-        userOps.deleteUser({ id: callerId, organizationId }, (err) => {
-          if (err) return done(err)
-          teamOps.deleteTeam({ id: calledTeamId, organizationId }, (err) => {
-            if (err) return done(err)
-            policyOps.deletePolicy({ id: policyId, organizationId }, done)
-          })
-        })
+      const test = prepareTest(lab, {
+        teams: {
+          calledTeam: { name: 'called team', organizationId }
+        },
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
       })
 
       lab.afterEach((done) => {
@@ -549,6 +530,7 @@ lab.experiment('Routes Authorizations', () => {
           Action: ['authorization:users:create'],
           Resource: ['/authorization/user/WONKA/*']
         }])
+        policyData.id = test.res.testedPolicy.id
 
         policyOps.updatePolicy(policyData, (err, policy) => {
           if (err) return done(err)
@@ -557,7 +539,7 @@ lab.experiment('Routes Authorizations', () => {
             method: 'POST',
             url: `/authorization/users`,
             payload: userData,
-            headers: { authorization: callerId }
+            headers: { authorization: test.res.caller.id }
           })
 
           server.inject(options, (response) => {
@@ -574,6 +556,7 @@ lab.experiment('Routes Authorizations', () => {
           Action: ['authorization:users:dummy'],
           Resource: ['/authorization/user/WONKA/*']
         }])
+        policyData.id = test.res.testedPolicy.id
 
         policyOps.updatePolicy(policyData, (err, policy) => {
           if (err) return done(err)
@@ -582,7 +565,7 @@ lab.experiment('Routes Authorizations', () => {
             method: 'POST',
             url: `/authorization/users`,
             payload: userData,
-            headers: { authorization: callerId }
+            headers: { authorization: test.res.caller.id }
           })
 
           server.inject(options, (response) => {
@@ -599,6 +582,7 @@ lab.experiment('Routes Authorizations', () => {
           Action: ['authorization:users:create'],
           Resource: ['dummy']
         }])
+        policyData.id = test.res.testedPolicy.id
 
         policyOps.updatePolicy(policyData, (err, policy) => {
           if (err) return done(err)
@@ -607,7 +591,7 @@ lab.experiment('Routes Authorizations', () => {
             method: 'POST',
             url: `/authorization/users`,
             payload: userData,
-            headers: { authorization: callerId }
+            headers: { authorization: test.res.caller.id }
           })
 
           server.inject(options, (response) => {
@@ -624,6 +608,7 @@ lab.experiment('Routes Authorizations', () => {
           Action: ['authorization:users:create'],
           Resource: ['/authorization/user/WONKA/team/*']
         }])
+        policyData.id = test.res.testedPolicy.id
 
         policyOps.updatePolicy(policyData, (err, policy) => {
           if (err) return done(err)
@@ -632,7 +617,7 @@ lab.experiment('Routes Authorizations', () => {
             method: 'POST',
             url: `/authorization/users`,
             payload: userData,
-            headers: { authorization: callerId }
+            headers: { authorization: test.res.caller.id }
           })
 
           server.inject(options, (response) => {


### PR DESCRIPTION
I opened this PR against my other PR so that changes to the code are clearer and it's hopefully easier to check if the new framework brings more clarity.

This PR currently contains the first step of such a framework: a function to build all initial records in one place. It is currently called `prepareTest` and returns an object intended to be later used to access created records (and in further iteration also dry-up the test definitions).

Two thing to note:
- Created records can be accessed by the key used in the records definition, but will have generic auto-generated ids
- Internally it still uses `lab.before` and `lab.after`, which I think is good for keeping everything in sync

At this time I'm seeking feedbacks on the type of approach and the "api definition" of the `prepareTest` function, basically this piece of code:

```js
      const test = prepareTest(lab, {
        teams: {
          calledTeam: { name: 'called team', organizationId, users: ['called'] }
        },
        users: {
          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
          called: { name: 'called', organizationId }
        },
        policies: {
          testedPolicy: Policy()
        }
       })
```

Please go light on the implementation has it is still temporary to demonstrate my intentions (it will probably be moved to utils)

Next steps will be:
- use `prepareTest` in all experiments in this file, expand as needed
- create framework to define auth tests, something along the lines of
```js
      test('should authorize caller with policy for specific users')
        .withPolicy([{
          Effect: 'Allow',
          Action: ['authorization:users:read'],
          Resource: [`/authorization/user/WONKA/*/${calledId}`]
        }])
        .endpoint({
          method: 'GET',
          url: `/authorization/users/${calledId}`,
          headers: { authorization: callerId }
        })
        .shouldRespond(200)
```