### PR TITLE
Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: node_js
+
+node_js:
+  - '6'
+  - '7'
+
+dist: trusty
+sudo: required
+
+env:
+  global:
+  - NODE_ENV=test
+  - LABS_AUTH_SERVICE_pgdb_password=''
+
+addons:
+  postgresql: "9.5"
+
+services:
+  - postgresql
+
+before_script:
+  - psql -c 'create database "authorization";' -U postgres

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # labs-authorization
+[![Travis][BadgeTravis]][Travis]
+
 
 A component providing authorization functionality
 
@@ -189,3 +191,6 @@ To achieve this we use the [`reconfig`](https://github.com/namshi/reconfig) modu
 This looks somewhat as follows:
 
 ![Authorization Architecture](./docs/authorization.png)
+
+[BadgeTravis]: https://travis-ci.org/nearform/labs-authorization.svg?branch=master
+[Travis]: https://travis-ci.org/nearform/labs-authorization?branch=master


### PR DESCRIPTION
Set Travis to run tests with **Node 6** on **Ubuntu 14**. Tests are fired on both push and PR.
For DB used the default install password overwriting the config one.

The OSX build seems to not start after tens of minutes, they have long processing queues. Choose to go only with Linux.