### PR TITLE
Issue 265 pre commit hook only on staged files

### DIFF
--- a/linter.js
+++ b/linter.js
@@ -4,46 +4,66 @@
  * This script will run the coding standard only for the staged files that are about to be committed
  */
 
+const uuid = require('uuid/v4')
 const git = require('simple-git')()
 const linter = require('spacey-standard')
 const sgf = require('staged-git-files')
+const stashIdentifier = 'linterStash' + uuid()
 
 function done (err, exitStatus = 0) {
   if (err) console.log(err)
 
-  return git.stash({'pop': null}, (err) => {
-    if (err) console.log(err)
-    process.exit(exitStatus)
+  git.stash({ 'list': null }, (err, list) => {
+    if (err) {
+      console.log(err)
+      process.exit(1)
+    }
+
+    if (list.indexOf(stashIdentifier) === -1) {
+      console.log('Notice: Will not run git stash pop, nothing to pop')
+      return process.exit(exitStatus)
+    }
+
+    git.stash({'pop': null}, (err) => {
+      if (err) console.log(err)
+      process.exit(exitStatus)
+    })
   })
 }
 
-git.stash({ '-k': null }, (err, res) => {
+git.stash({ 'save': null, '-k': null, [stashIdentifier]: null }, (err, res) => {
   if (err) {
     console.log(err)
     process.exit(1)
   }
 
-  sgf(function (err, result) {
+  sgf(function (err, files) {
+    let exitStatus = 0
+
     if (err) {
       return done(err, 1)
     }
 
-    const files = result.map(f => f.filename).filter(f => f.endsWith('.js'))
-    let exitStatus = 0
+    files = files.map(f => f.filename).filter(f => f.endsWith('.js'))
 
     linter.lintFiles(files, (err, result) => {
       if (err) {
         done(err, 1)
       }
 
+      const errors = []
       if (result.results.length > 0) {
-        console.log('Linter errors:')
         result.results.forEach((res) => {
           res.messages.forEach((message) => {
-            exitStatus = 1
-            console.log(`${res.filePath}:${message.line || 0}:${message.column || 0}  ${message.message}`)
+            errors.push(`${res.filePath}:${message.line || 0}:${message.column || 0}  ${message.message}`)
           })
         })
+      }
+
+      if (errors.length > 0) {
+        exitStatus = 1
+        console.log('Linter errors:')
+        errors.forEach(e => console.log(e))
       }
 
       done(null, exitStatus)

--- a/linter.js
+++ b/linter.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * This script will run the coding standard only for the staged files that are about to be committed
+ */
+
+const git = require('simple-git')()
+const linter = require('spacey-standard')
+const sgf = require('staged-git-files')
+
+function done (err, exitStatus = 0) {
+  if (err) console.log(err)
+
+  return git.stash({'pop': null}, (err) => {
+    if (err) console.log(err)
+    process.exit(exitStatus)
+  })
+}
+
+git.stash({ '-k': null }, (err, res) => {
+  if (err) {
+    console.log(err)
+    process.exit(1)
+  }
+
+  sgf(function (err, result) {
+    if (err) {
+      return done(err, 1)
+    }
+
+    const files = result.map(f => f.filename).filter(f => f.endsWith('.js'))
+    let exitStatus = 0
+
+    linter.lintFiles(files, (err, result) => {
+      if (err) {
+        done(err, 1)
+      }
+
+      if (result.results.length > 0) {
+        console.log('Linter errors:')
+        result.results.forEach((res) => {
+          res.messages.forEach((message) => {
+            exitStatus = 1
+            console.log(`${res.filePath}:${message.line || 0}:${message.column || 0}  ${message.message}`)
+          })
+        })
+      }
+
+      done(null, exitStatus)
+    })
+  })
+})
+

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
     "pg:stop": "docker-compose down",
     "pg:init": "LABS_AUTH_SERVICE_local=true node database/init.js && npm run migrate",
     "pg:load-test-data": "LABS_AUTH_SERVICE_local=true node database/loadTestData.js",
-    "app:init-test-db": "npm run pg:init && npm run pg:load-test-data"
+    "app:init-test-db": "npm run pg:init && npm run pg:load-test-data",
+    "lint-staged-files": "node ./linter.js"
   },
   "pre-commit": [
-    "lint"
+    "lint-staged-files"
   ],
   "repository": {
     "type": "git",
@@ -53,6 +54,8 @@
     "postgrator": "2.8.2",
     "pre-commit": "1.2.2",
     "proxyquire": "1.7.10",
-    "spacey-standard": "4.0.0"
+    "simple-git": "^1.65.0",
+    "spacey-standard": "4.0.0",
+    "staged-git-files": "0.0.4"
   }
 }


### PR DESCRIPTION
This PR add the ability to run pre-commit linting only on staged files.

The output will be something like this

![screenshot 2017-01-19 11 50 01](https://cloud.githubusercontent.com/assets/272483/22103983/842aa9bc-de3d-11e6-9e3b-e2adca5c533a.png)

The flow is:

- git stash only [unstaged changes](https://github.com/nearform/labs-authorization/pull/297/files#diff-87d41a187bfa2e196628052abbf001a9R34) (with a [specific comment](https://github.com/nearform/labs-authorization/pull/297/files#diff-87d41a187bfa2e196628052abbf001a9R11))
- run linting [only on `.js` files](https://github.com/nearform/labs-authorization/pull/297/files#diff-87d41a187bfa2e196628052abbf001a9R47)
- report errors (if any)
- git pop if the initial stash was created (empty* stashes will not be created)

* if you have something staged an no other modification an empty stash is created anyway

