### PR TITLE
Fix adding other organization policies to team

### DIFF
--- a/src/lib/ops/utils.js
+++ b/src/lib/ops/utils.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Boom = require('boom')
+const SQL = require('./../db/SQL')
 
 function boomErrorWrapper (next) {
   return function wrapAsBadImplementation (err, result) {
@@ -12,7 +13,59 @@ function isUniqueViolationError (err) {
   return err && err.code === '23505'
 }
 
+function checkPoliciesOrg (db, policies, organizationId, cb) {
+  db.query(SQL`SELECT id FROM policies WHERE id = ANY (${policies}) AND org_id != ${organizationId}`, (err, result) => {
+    if (err) return cb(Boom.badImplementation(err))
+
+    if (result.rowCount !== 0) {
+      return cb(Boom.badRequest(`Some policies [${result.rows.map(r => r.id).join(',')}] were not found`))
+    }
+
+    cb()
+  })
+}
+
+function checkUsersOrg (db, users, organizationId, cb) {
+  db.query(SQL`SELECT id FROM users WHERE id = ANY (${users}) AND org_id != ${organizationId}`, (err, result) => {
+    if (err) return cb(Boom.badImplementation(err))
+
+    if (result.rowCount !== 0) {
+      return cb(Boom.badRequest(`Some users [${result.rows.map(r => r.id).join(',')}] were not found`))
+    }
+
+    cb()
+  })
+}
+
+function checkTeamsOrg (db, teams, organizationId, cb) {
+  db.query(SQL`SELECT id FROM teams WHERE id = ANY (${teams}) AND org_id != ${organizationId}`, (err, result) => {
+    if (err) return cb(Boom.badImplementation(err))
+
+    if (result.rowCount !== 0) {
+      return cb(Boom.badRequest(`Some teams [${result.rows.map(r => r.id).join(',')}] were not found`))
+    }
+
+    cb()
+  })
+}
+
+function checkUserOrg (db, id, organizationId, cb) {
+  db.query(SQL`SELECT id FROM users WHERE id = ${id} AND org_id = ${organizationId}`, (err, result) => {
+    if (err) return cb(Boom.badImplementation(err))
+
+    if (result.rowCount !== 1) {
+      return cb(Boom.badRequest(`User ${id} not found`))
+    }
+
+    cb()
+  })
+}
+
 module.exports = {
-  boomErrorWrapper: boomErrorWrapper,
-  isUniqueViolationError: isUniqueViolationError
+  boomErrorWrapper,
+  isUniqueViolationError,
+  checkPoliciesOrg,
+  checkUsersOrg,
+  checkTeamsOrg,
+  checkUserOrg
 }

--- a/src/routes/headers.js
+++ b/src/routes/headers.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const Joi = require('joi')
+
+const headers = Joi.object({
+  'authorization': Joi.any().required().description('user id of who is calling the enpoint'),
+  'org': Joi.any().description('Specify a different organization for the user who is calling the endpoint (works only for SuperUser, it\'s like impersonation)')
+}).unknown()
+
+module.exports = headers

--- a/src/routes/private/policies.js
+++ b/src/routes/private/policies.js
@@ -6,6 +6,7 @@ const serviceKey = require('./../../security/serviceKey')
 const Action = require('./../../lib/config/config.auth').Action
 const policyOps = require('./../../lib/ops/policyOps')
 const swagger = require('./../../swagger')
+const headers = require('./../headers')
 
 exports.register = function (server, options, next) {
 
@@ -45,9 +46,7 @@ exports.register = function (server, options, next) {
         query: {
           sig: Joi.string().required()
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Create a policy for the current user organization',
       notes: 'The POST /authorization/policies endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
@@ -94,9 +93,7 @@ exports.register = function (server, options, next) {
         query: {
           sig: Joi.string().required()
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Update a policy of the current user organization',
       notes: 'The PUT /authorization/policies/{id} endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
@@ -137,7 +134,8 @@ exports.register = function (server, options, next) {
           sig: Joi.string().required()
         },
         headers: Joi.object({
-          'authorization': Joi.any().required()
+          'authorization': Joi.any().required().description('user id of who is calling the enpoint'),
+          'org': Joi.any().description('Specify a different organization for the user who is calling the endpoint (works only for SuperUser)')
         }).unknown()
       },
       description: 'Delete a policy',

--- a/src/routes/public/authorization.js
+++ b/src/routes/public/authorization.js
@@ -2,8 +2,8 @@
 
 const Joi = require('joi')
 const Action = require('./../../lib/config/config.auth').Action
-
 const authorize = require('./../../lib/ops/authorizeOps')
+const headers = require('./../headers')
 
 exports.register = function (server, options, next) {
 
@@ -36,9 +36,7 @@ exports.register = function (server, options, next) {
           action: Joi.string().required().description('The action to check'),
           resource: Joi.string().required().description('The resource that the user wants to perform the action on')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Authorize user action against a resource',
       notes: 'The GET /authorization/check/{userId}/{action}/{resource} endpoint returns if a user can perform and action\non a resource\n',
@@ -75,9 +73,7 @@ exports.register = function (server, options, next) {
           userId: Joi.string().required().description('The user that wants to perform the action on a given resource'),
           resource: Joi.string().required().description('The resource that the user wants to perform the action on')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'List all the actions a user can perform on a resource',
       notes: 'The GET /authorization/list/{userId}/{resource} endpoint returns a list of all the actions a user\ncan perform on a given resource\n',

--- a/src/routes/public/organizations.js
+++ b/src/routes/public/organizations.js
@@ -4,6 +4,7 @@ const Joi = require('joi')
 const organizationOps = require('./../../lib/ops/organizationOps')
 const Action = require('./../../lib/config/config.auth').Action
 const swagger = require('./../../swagger')
+const headers = require('./../headers')
 
 exports.register = function (server, options, next) {
 
@@ -22,9 +23,7 @@ exports.register = function (server, options, next) {
         }
       },
       validate: {
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       response: {schema: swagger.OrganizationList}
     }
@@ -49,9 +48,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('organization id')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       response: {schema: swagger.Organization}
     }
@@ -87,9 +84,7 @@ exports.register = function (server, options, next) {
             name: Joi.string().required()
           })
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Create an organization',
       notes: 'The POST /authorization/organizations endpoint will create a new organization, the default organization admin policy and (if provided) its admin.',
@@ -129,9 +124,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('organization id')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       }
     }
   })
@@ -154,9 +147,7 @@ exports.register = function (server, options, next) {
           name: Joi.string().required().description('organization name'),
           description: Joi.string().required().description('organization description')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Update an organization',
       notes: 'The PUT /authorization/organizations/{id} endpoint will update an organization name and description',

--- a/src/routes/public/policies.js
+++ b/src/routes/public/policies.js
@@ -4,6 +4,7 @@ const Joi = require('joi')
 const policyOps = require('./../../lib/ops/policyOps')
 const Action = require('./../../lib/config/config.auth').Action
 const swagger = require('./../../swagger')
+const headers = require('./../headers')
 
 exports.register = function (server, options, next) {
   server.route({
@@ -24,9 +25,7 @@ exports.register = function (server, options, next) {
         }
       },
       validate: {
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       response: {schema: swagger.PolicyList}
     }
@@ -46,9 +45,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('policy id')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Fetch all the defined policies',
       notes: 'The GET /authorization/policies/{id} endpoint returns a single policy based on it\'s id.\n',

--- a/src/routes/public/teams.js
+++ b/src/routes/public/teams.js
@@ -4,6 +4,7 @@ const Joi = require('joi')
 const teamOps = require('./../../lib/ops/teamOps')
 const Action = require('./../../lib/config/config.auth').Action
 const swagger = require('./../../swagger')
+const headers = require('./../headers')
 
 exports.register = function (server, options, next) {
 
@@ -24,9 +25,7 @@ exports.register = function (server, options, next) {
         }
       },
       validate: {
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       response: {schema: swagger.TeamList}
     }
@@ -67,9 +66,7 @@ exports.register = function (server, options, next) {
             name: Joi.string().required('Name for the user')
           })
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Create a team',
       notes: 'The POST /authorization/teams endpoint creates a new team given its data\n',
@@ -97,9 +94,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('The team ID')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Fetch a team given its identifier',
       notes: 'The GET /authorization/teams/{id} endpoint returns a single team data\n',
@@ -140,9 +135,7 @@ exports.register = function (server, options, next) {
           name: Joi.string().description('Updated team name'),
           description: Joi.string().description('Updated team description')
         }).or('name', 'description'),
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Update a team',
       notes: 'The PUT /authorization/teams endpoint updates a team data\n',
@@ -177,9 +170,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('The team ID')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Delete a team',
       notes: 'The DELETE /authorization/teams endpoint deletes a team\n',
@@ -221,9 +212,7 @@ exports.register = function (server, options, next) {
         payload: {
           parentId: Joi.string().required().description('The new parent ID')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Nest a team',
       notes: 'The PUT /authorization/teams/{id}/nest endpoint nests a team\n',
@@ -263,9 +252,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('The team ID')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Unnest a team',
       notes: 'The PUT /authorization/teams/{id}/unnest endpoint unnests a team\n',
@@ -303,9 +290,7 @@ exports.register = function (server, options, next) {
         payload: {
           policies: Joi.array().items(Joi.string()).required().description('Policy ids')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Add one or more policies to a team',
       notes: 'The PUT /authorization/teams/{id}/policies endpoint add one or more new policies to a team\n',
@@ -344,9 +329,7 @@ exports.register = function (server, options, next) {
         payload: {
           policies: Joi.array().items(Joi.string()).required().description('Policy ids')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Clear and replace policies for a team',
       notes: 'The POST /authorization/teams/{id}/policies endpoint removes all the team policies and replace them\n',
@@ -381,9 +364,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('Team id')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Clear all team policies',
       notes: 'The DELETE /authorization/teams/{id}/policies endpoint removes all the team policies\n',
@@ -418,9 +399,7 @@ exports.register = function (server, options, next) {
           teamId: Joi.string().required().description('Team id'),
           policyId: Joi.string().required().description('Policy id')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Remove a team policy',
       notes: 'The DELETE /authorization/teams/{teamId}/policies/{policyId} endpoint removes a specific team policy\n',
@@ -452,9 +431,7 @@ exports.register = function (server, options, next) {
           page: Joi.number().integer().positive().required().description('Page number, starts from 1'),
           limit: Joi.number().integer().positive().required().description('Users per page')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Fetch team users given its identifier',
       notes: 'The GET /authorization/teams/{id}/users endpoint returns the users from a team and metadata related to pagination. The results are paginated. Page numbers start from 1. \n',
@@ -493,9 +470,7 @@ exports.register = function (server, options, next) {
         payload: Joi.object().keys({
           users: Joi.array().items(Joi.string()).description('User ids')
         }),
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Add team members',
       notes: 'The PUT /authorization/teams/{id}/users endpoint adds one or more team members',
@@ -534,9 +509,7 @@ exports.register = function (server, options, next) {
         payload: Joi.object().keys({
           users: Joi.array().items(Joi.string()).description('User ids')
         }),
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Replace team members with the given ones',
       notes: 'The POST /authorization/teams/{id}/users endpoint replaces all team members',
@@ -571,9 +544,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('The team ID')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Delete all team members with the given ones',
       notes: 'The DELETE /authorization/teams/{id}/users endpoint removes all members of a team',
@@ -608,9 +579,7 @@ exports.register = function (server, options, next) {
           id: Joi.string().required().description('The team ID'),
           userId: Joi.string().required().description('The user ID')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Delete one team member',
       notes: 'The DELETE /authorization/teams/{id}/users/{userId} endpoint removes one member of a team',

--- a/src/routes/public/users.js
+++ b/src/routes/public/users.js
@@ -4,6 +4,7 @@ const Joi = require('joi')
 const userOps = require('./../../lib/ops/userOps')
 const Action = require('./../../lib/config/config.auth').Action
 const swagger = require('./../../swagger')
+const headers = require('./../headers')
 
 exports.register = function (server, options, next) {
 
@@ -24,9 +25,7 @@ exports.register = function (server, options, next) {
         }
       },
       validate: {
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       response: {schema: swagger.UserList}
     }
@@ -46,9 +45,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('user id')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Fetch a user given its identifier',
       notes: 'The GET /authorization/users/{id} endpoint returns a single user data\n',
@@ -84,9 +81,7 @@ exports.register = function (server, options, next) {
           id: Joi.string().description('user id'),
           name: Joi.string().required().description('User name')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Create a new user',
       notes: 'The POST /authorization/users endpoint creates a new user given its data\n',
@@ -120,9 +115,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('user id')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Delete a user',
       notes: 'The DELETE /authorization/users endpoint delete a user\n',
@@ -159,9 +152,7 @@ exports.register = function (server, options, next) {
         payload: {
           name: Joi.string().required().description('user name')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Update a user',
       notes: 'The PUT /authorization/users endpoint updates a user data\n',
@@ -199,9 +190,7 @@ exports.register = function (server, options, next) {
         payload: {
           policies: Joi.array().required().items(Joi.string().required())
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Add one or more policies to a user',
       notes: 'The PUT /authorization/users/{id}/policies endpoint add one or more new policies to a user\n',
@@ -240,9 +229,7 @@ exports.register = function (server, options, next) {
         payload: {
           policies: Joi.array().required().items(Joi.string().required())
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Clear and replace policies for a user',
       notes: 'The POST /authorization/users/{id}/policies endpoint removes all the user policies and replace them\n',
@@ -277,9 +264,7 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.string().required().description('user id')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Clear all user\'s policies',
       notes: 'The DELETE /authorization/users/{id}/policies endpoint removes all the user policies\n',
@@ -314,9 +299,7 @@ exports.register = function (server, options, next) {
           userId: Joi.string().required().description('user id'),
           policyId: Joi.string().required().description('policy id')
         },
-        headers: Joi.object({
-          'authorization': Joi.any().required()
-        }).unknown()
+        headers
       },
       description: 'Remove a user\'s policy',
       notes: 'The DELETE /authorization/users/{userId}/policies/{policyId} endpoint removes a specific user\'s policy\n',

--- a/test/endToEnd/teamsTest.js
+++ b/test/endToEnd/teamsTest.js
@@ -616,6 +616,21 @@ lab.experiment('Teams - manage policies', () => {
     })
   })
 
+  lab.test('Add one policy from another org to a team should return an error', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/teams/1/policies',
+      payload: {
+        policies: ['policyId9']
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      done()
+    })
+  })
+
   lab.test('Add multiple policies to a team', (done) => {
     const options = utils.requestOptions({
       method: 'PUT',
@@ -656,6 +671,21 @@ lab.experiment('Teams - manage policies', () => {
       expect(result.policies).to.equal([{ id: 'policyId6', name: 'DB Only Read', version: '0.1' }])
 
       teamOps.replaceTeamPolicies({ id: result.id, policies: ['policyId1'], organizationId: result.organizationId }, done)
+    })
+  })
+
+  lab.test('Replace team policies from another org should return an error', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/teams/1/policies',
+      payload: {
+        policies: ['policyId9']
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      done()
     })
   })
 


### PR DESCRIPTION
This PR fixes adding/replacing policies for a team if the policies comes from another organization.

It also extracts some functions (`checkPoliciesOrg`, `checkUsersOrg`, ...) to the ops/utils module.

Ref. issue #300