### PR TITLE
Add statemets as an object instead of a string in policy creation/update

### DIFF
--- a/src/routes/private/policies.js
+++ b/src/routes/private/policies.js
@@ -41,7 +41,7 @@ exports.register = function (server, options, next) {
           id: Joi.string().allow('').description('policy id'),
           version: Joi.string().required().description('policy version'),
           name: Joi.string().required().description('policy name'),
-          statements: Joi.string().required().description('policy statements')
+          statements: swagger.PolicyStatements.required().description('policy statements')
         },
         query: {
           sig: Joi.string().required()
@@ -88,7 +88,7 @@ exports.register = function (server, options, next) {
         payload: {
           version: Joi.string().required().description('policy version'),
           name: Joi.string().required().description('policy name'),
-          statements: Joi.string().required().description('policy statements')
+          statements: swagger.PolicyStatements.required().description('policy statements')
         },
         query: {
           sig: Joi.string().required()

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -8,7 +8,7 @@ const PolicyStatements = Joi.object({
     Action: Joi.array().items(Joi.string()),
     Resource: Joi.array().items(Joi.string()),
     Sid: Joi.string(),
-    Condition: Joi.object({})
+    Condition: Joi.object()
   }))
 })
 
@@ -81,15 +81,16 @@ const OrganizationAndUser = Joi.object({
 const OrganizationList = Joi.array().items(Organization)
 
 module.exports = {
-  UserList: UserList,
-  MetadataUserList: MetadataUserList,
-  User: User,
-  TeamList: TeamList,
-  Team: Team,
-  PolicyList: PolicyList,
-  Policy: Policy,
-  PolicyRef: PolicyRef,
-  Organization: Organization,
-  OrganizationList: OrganizationList,
-  OrganizationAndUser: OrganizationAndUser
+  UserList,
+  MetadataUserList,
+  User,
+  TeamList,
+  Team,
+  PolicyList,
+  Policy,
+  PolicyRef,
+  Organization,
+  OrganizationList,
+  OrganizationAndUser,
+  PolicyStatements
 }

--- a/test/endToEnd/authorization/testBuilder.js
+++ b/test/endToEnd/authorization/testBuilder.js
@@ -9,13 +9,13 @@ function Policy (Statement) {
   return {
     version: '2016-07-01',
     name: 'Test Policy',
-    statements: JSON.stringify({
+    statements: {
       Statement: Statement || [{
         Effect: 'Allow',
         Action: ['dummy'],
         Resource: ['dummy']
       }]
-    })
+    }
   }
 }
 

--- a/test/endToEnd/authorization/usersTest.js
+++ b/test/endToEnd/authorization/usersTest.js
@@ -12,13 +12,13 @@ function Policy (Statement) {
   return {
     version: '2016-07-01',
     name: 'Test Policy',
-    statements: JSON.stringify({
+    statements: {
       Statement: Statement || [{
         Effect: 'Allow',
         Action: ['dummy'],
         Resource: ['dummy']
       }]
-    }),
+    },
     organizationId
   }
 }
@@ -395,13 +395,13 @@ lab.experiment('Routes Authorizations', () => {
             id: 'policy-to-add',
             version: '2016-07-01',
             name: 'Policy To Add',
-            statements: JSON.stringify({
+            statements: {
               Statement: [{
                 Effect: 'Allow',
                 Action: ['an-action'],
                 Resource: ['a-resource']
               }]
-            }),
+            },
             organizationId
           }
         }
@@ -482,13 +482,13 @@ lab.experiment('Routes Authorizations', () => {
             id: 'policy-to-add',
             version: '2016-07-01',
             name: 'Policy To Add',
-            statements: JSON.stringify({
+            statements: {
               Statement: [{
                 Effect: 'Allow',
                 Action: ['an-action'],
                 Resource: ['a-resource']
               }]
-            }),
+            },
             organizationId
           }
         }
@@ -569,13 +569,13 @@ lab.experiment('Routes Authorizations', () => {
             id: 'policy-to-delete',
             version: '2016-07-01',
             name: 'Policy To Delete',
-            statements: JSON.stringify({
+            statements: {
               Statement: [{
                 Effect: 'Allow',
                 Action: ['an-action'],
                 Resource: ['a-resource']
               }]
-            }),
+            },
             organizationId
           }
         }
@@ -655,13 +655,13 @@ lab.experiment('Routes Authorizations', () => {
             id: 'policy-to-delete',
             version: '2016-07-01',
             name: 'Policy To Delete',
-            statements: JSON.stringify({
+            statements: {
               Statement: [{
                 Effect: 'Allow',
                 Action: ['an-action'],
                 Resource: ['a-resource']
               }]
-            }),
+            },
             organizationId
           }
         }

--- a/test/endToEnd/policiesTest.js
+++ b/test/endToEnd/policiesTest.js
@@ -7,10 +7,19 @@ var utils = require('./../utils')
 var policyOps = require('./../../src/lib/ops/policyOps')
 var server = require('./../../src/wiring-hapi')
 
+const statements = {
+  Statement: [
+    {
+      Effect: 'Allow',
+      Action: ['documents:Read'],
+      Resource: ['wonka:documents:/public/*']
+    }
+  ]
+}
 const policyCreateData = {
   version: '2016-07-01',
   name: 'Documents Admin',
-  statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}',
+  statements,
   organizationId: 'WONKA'
 }
 
@@ -94,7 +103,7 @@ lab.experiment('Policies - create/update/delete (need service key)', () => {
       payload: {
         version: '2016-07-01',
         name: 'Documents Admin',
-        statements: 'fake-statements'
+        statements
       }
     })
 
@@ -130,7 +139,7 @@ lab.experiment('Policies - create/update/delete (need service key)', () => {
         id: 'policyId1',
         version: '2016-07-01',
         name: 'Documents Admin',
-        statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+        statements
       }
     })
 
@@ -149,7 +158,7 @@ lab.experiment('Policies - create/update/delete (need service key)', () => {
       payload: {
         version: '2016-07-01',
         name: 'Documents Admin',
-        statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+        statements
       }
     })
 
@@ -158,6 +167,7 @@ lab.experiment('Policies - create/update/delete (need service key)', () => {
 
       expect(response.statusCode).to.equal(201)
       expect(result.name).to.equal('Documents Admin')
+      expect(result.statements).to.equal(statements)
 
       policyOps.deletePolicy({ id: result.id, organizationId: 'WONKA' }, done)
     })
@@ -171,7 +181,7 @@ lab.experiment('Policies - create/update/delete (need service key)', () => {
         id: '',
         version: '2016-07-01',
         name: 'Documents Admin',
-        statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+        statements
       }
     })
 
@@ -194,7 +204,7 @@ lab.experiment('Policies - create/update/delete (need service key)', () => {
         id: 'mySpecialPolicyId',
         version: '2016-07-01',
         name: 'Documents Admin',
-        statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+        statements
       }
     })
 
@@ -216,7 +226,7 @@ lab.experiment('Policies - create/update/delete (need service key)', () => {
       payload: {
         version: '2016-07-01',
         name: 'Documents Admin',
-        statements: 'fake-statements'
+        statements
       }
     })
 
@@ -254,7 +264,15 @@ lab.experiment('Policies - create/update/delete (need service key)', () => {
         payload: {
           version: '1234',
           name: 'new policy name',
-          statements: '{"Statement":[{"Effect":"Deny","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+          statements: {
+            Statement: [
+              {
+                Effect: 'Deny',
+                Action: ['documents:Read'],
+                Resource: ['wonka:documents:/public/*']
+              }
+            ]
+          }
         }
       })
 

--- a/test/endToEnd/policiesTest.js
+++ b/test/endToEnd/policiesTest.js
@@ -7,15 +7,7 @@ var utils = require('./../utils')
 var policyOps = require('./../../src/lib/ops/policyOps')
 var server = require('./../../src/wiring-hapi')
 
-const statements = {
-  Statement: [
-    {
-      Effect: 'Allow',
-      Action: ['documents:Read'],
-      Resource: ['wonka:documents:/public/*']
-    }
-  ]
-}
+const statements = { Statement: [{ Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*'] }] }
 const policyCreateData = {
   version: '2016-07-01',
   name: 'Documents Admin',

--- a/test/endToEnd/usersTest.js
+++ b/test/endToEnd/usersTest.js
@@ -9,10 +9,12 @@ const organizationOps = require('../../src/lib/ops/organizationOps')
 const policyOps = require('../../src/lib/ops/policyOps')
 const server = require('./../../src/wiring-hapi')
 
+const statements = { Statement: [{ Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*'] }] }
+
 const policyCreateData = {
   version: '2016-07-01',
   name: 'Documents Admin',
-  statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}',
+  statements,
   organizationId: 'WONKA'
 }
 
@@ -404,7 +406,7 @@ lab.experiment('Users - checking org_id scoping', () => {
         version: 1,
         name: 'Documents Admin',
         organizationId: 'NEWORG',
-        statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+        statements
       }
 
       policyOps.createPolicy(policyData, (err, policy) => {

--- a/test/lib/integration/authorizeOpsTest.js
+++ b/test/lib/integration/authorizeOpsTest.js
@@ -27,7 +27,6 @@ const updateUserData = {
   teams: null
 }
 
-
 lab.experiment('AuthorizeOps', () => {
 
   let testUserId
@@ -314,11 +313,6 @@ lab.experiment('AuthorizeOps - list and access with multiple policies', () => {
 
   lab.before((done) => {
     const policies = JSON.parse(fs.readFileSync(path.join(__dirname, 'policies.json'), { encoding: 'utf8' }))
-    policies.map((policy) => {
-      policy.statements = JSON.stringify(policy.statements)
-
-      return policy
-    })
 
     organizationOps.create({ id: organizationId, name: 'nearForm', description: 'nearform description', user: { name: 'admin' } }, (err, res) => {
       if (err) return done(err)

--- a/test/lib/integration/organizationOpsTest.js
+++ b/test/lib/integration/organizationOpsTest.js
@@ -16,6 +16,8 @@ const defaultPoliciesNames = Object.keys(defaultPolicies).map((pName) => {
   return policy.name
 })
 
+const statements = { Statement: [{ Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*'] }] }
+
 lab.experiment('OrganizationOps', () => {
 
   lab.test('list of all organizations', (done) => {
@@ -200,7 +202,7 @@ lab.experiment('OrganizationOps', () => {
       version: '2016-07-01',
       name: 'Documents Admin',
       organizationId: 'nearForm222',
-      statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+      statements
     }
 
     const tasks = []

--- a/test/lib/integration/policyOpsTest.js
+++ b/test/lib/integration/policyOpsTest.js
@@ -5,6 +5,7 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 
 const policyOps = require('../../../src/lib/ops/policyOps')
+const statements = { Statement: [{ Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*'] }] }
 
 lab.experiment('PolicyOps', () => {
 
@@ -43,7 +44,7 @@ lab.experiment('PolicyOps', () => {
       version: 1,
       name: 'Documents Admin',
       organizationId: 'WONKA',
-      statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+      statements
     }
 
     policyOps.createPolicy(policyData, (err, policy) => {
@@ -54,14 +55,14 @@ lab.experiment('PolicyOps', () => {
 
       expect(policy.name).to.equal('Documents Admin')
       expect(policy.version).to.equal('1')
-      expect(policy.statements).to.equal({ Statement: [{ Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*'] }] })
+      expect(policy.statements).to.equal(statements)
 
       const updateData = {
         id: policyId,
         organizationId: 'WONKA',
         version: 2,
         name: 'Documents Admin v2',
-        statements: '{"Statement":[{"Effect":"Deny","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+        statements: { Statement: [{ Effect: 'Deny', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*'] }] }
       }
 
       policyOps.updatePolicy(updateData, (err, policy) => {
@@ -83,7 +84,7 @@ lab.experiment('PolicyOps', () => {
       version: 1,
       name: 'Documents Admin',
       organizationId: 'WONKA',
-      statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+      statements
     }
 
     policyOps.createPolicy(policyData, (err, policy) => {
@@ -93,7 +94,7 @@ lab.experiment('PolicyOps', () => {
       expect(policy.id).to.equal('MySpecialId')
       expect(policy.name).to.equal('Documents Admin')
       expect(policy.version).to.equal('1')
-      expect(policy.statements).to.equal({ Statement: [{ Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*'] }] })
+      expect(policy.statements).to.equal(statements)
 
       policyOps.deletePolicy({ id: policy.id, organizationId: 'WONKA' }, done)
     })

--- a/test/lib/integration/teamOpsTest.js
+++ b/test/lib/integration/teamOpsTest.js
@@ -11,6 +11,8 @@ const teamOps = require('../../../src/lib/ops/teamOps')
 const policyOps = require('../../../src/lib/ops/policyOps')
 const userOps = require('../../../src/lib/ops/userOps')
 
+const statements = { Statement: [{ Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*'] }] }
+
 function randomId () {
   return crypto.randomBytes(2).toString('hex')
 }
@@ -31,7 +33,7 @@ lab.experiment('TeamOps', () => {
         version: 1,
         name: randomId(),
         organizationId: 'WONKA',
-        statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+        statements
       }, (err, createdPolicy) => {
         expect(err).to.not.exist()
         expect(createdPolicy).to.exist()
@@ -41,7 +43,7 @@ lab.experiment('TeamOps', () => {
           version: 1,
           name: randomId(),
           organizationId: 'WONKA',
-          statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+          statements
         }, (err, createdPolicy) => {
           expect(err).to.not.exist()
           expect(createdPolicy).to.exist()
@@ -52,7 +54,7 @@ lab.experiment('TeamOps', () => {
             version: 1,
             name: randomId(),
             organizationId: 'ROOT',
-            statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+            statements
           }, (err, createdPolicy) => {
             expect(err).to.not.exist()
             expect(createdPolicy).to.exist()


### PR DESCRIPTION
This PR changes the policy `statemets` property from a string to an object when creating or updating a policy.

Ref. issue #284 