### PR TITLE
Issue 301 udaru module

### DIFF
--- a/src/lib/ops/userOps.js
+++ b/src/lib/ops/userOps.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Joi = require('joi')
 const Boom = require('boom')
 const async = require('async')
 const uuidV4 = require('uuid/v4')
@@ -7,8 +8,9 @@ const db = require('./../db')
 const SQL = require('./../db/SQL')
 const mapping = require('./../mapping')
 const utils = require('./utils')
+const validationRules = require('./validation').users
 
-const clearUserPolicies = (job, next) => {
+function clearUserPolicies (job, next) {
   const { id } = job
 
   const sqlQuery = SQL`
@@ -18,7 +20,7 @@ const clearUserPolicies = (job, next) => {
   job.client.query(sqlQuery, utils.boomErrorWrapper(next))
 }
 
-const removeUserPolicy = (job, next) => {
+function removeUserPolicy (job, next) {
   const { id, policyId } = job
 
   const sqlQuery = SQL`
@@ -29,7 +31,7 @@ const removeUserPolicy = (job, next) => {
   job.client.query(sqlQuery, utils.boomErrorWrapper(next))
 }
 
-const insertUserPolicies = (job, next) => {
+function insertUserPolicies (job, next) {
   const { id: userId, policies } = job
 
   userOps.insertPolicies(job.client, userId, policies, utils.boomErrorWrapper(next))
@@ -45,28 +47,370 @@ const userOps = {
   /**
    * Get organization users, in alphabetical order
    *
-   * @param  {Object}   params { organizationId }
+   * @param  {Object}   params { organizationId, page, limit }
    * @param  {Function} cb
    */
   listOrgUsers: function listOrgUsers (params, cb) {
-    const { organizationId } = params
+    const { organizationId, page, limit } = params
 
-    const sqlQuery = SQL`
-      WITH total AS (
-        SELECT COUNT(*)::INTEGER AS cnt
+    Joi.validate({ organizationId, page, limit }, validationRules.listOrgUsers, function (err) {
+      if (err) return cb(Boom.badRequest(err))
+
+      const sqlQuery = SQL`
+        WITH total AS (
+          SELECT COUNT(*)::INTEGER AS cnt
+          FROM users
+          WHERE org_id = ${organizationId}
+        )
+        SELECT *, t.cnt AS total
         FROM users
+        INNER JOIN total AS t on 1=1
         WHERE org_id = ${organizationId}
-      )
-      SELECT *, t.cnt AS total
-      FROM users
-      INNER JOIN total AS t on 1=1
-      WHERE org_id = ${organizationId}
-      ORDER BY UPPER(name)
-    `
-    db.query(sqlQuery, function (err, result) {
+        ORDER BY UPPER(name)
+      `
+
+      if (limit) {
+        sqlQuery.append(SQL` LIMIT ${limit}`)
+      }
+      if (limit && page) {
+        let offset = (page - 1) * limit
+        sqlQuery.append(SQL` OFFSET ${offset}`)
+      }
+
+      db.query(sqlQuery, function (err, result) {
+        if (err) return cb(err)
+        let total = result.rows.length > 0 ? result.rows[0].total : 0
+        return cb(null, result.rows.map(mapping.user), total)
+      })
+    })
+  },
+
+  /**
+   * Get user details
+   *
+   * @param  {Object}   params { id, organizationId }
+   * @param  {Function} cb
+   */
+  readUser: function readUser (params, cb) {
+    const { id, organizationId } = params
+    let user
+
+    const tasks = []
+
+    tasks.push((next) => {
+      Joi.validate({ id, organizationId }, validationRules.readUser, (err) => {
+        if (err) return next(Boom.badRequest(err))
+
+        next()
+      })
+    })
+
+    tasks.push((next) => {
+      const sqlQuery = SQL`
+        SELECT id, name, org_id
+        FROM users
+        WHERE id = ${id}
+        AND org_id = ${organizationId}
+      `
+      db.query(sqlQuery, (err, result) => {
+        if (err) return next(Boom.badImplementation(err))
+        if (result.rowCount === 0) return next(Boom.notFound(`User ${id} not found`))
+
+        user = mapping.user(result.rows[0])
+        next()
+      })
+    })
+
+    tasks.push((next) => {
+      const sqlQuery = SQL`
+        SELECT teams.id, teams.name
+        FROM team_members mem, teams
+        WHERE mem.user_id = ${id} AND mem.team_id = teams.id
+        ORDER BY UPPER(teams.name)
+      `
+      db.query(sqlQuery, (err, result) => {
+        if (err) return next(Boom.badImplementation(err))
+
+        user.teams = result.rows.map(mapping.team.simple)
+        next()
+      })
+    })
+
+    tasks.push((next) => {
+      const sqlQuery = SQL`
+        SELECT pol.id, pol.name, pol.version
+        FROM user_policies user_pol, policies pol
+        WHERE user_pol.user_id = ${id} AND user_pol.policy_id = pol.id
+        ORDER BY UPPER(pol.name)
+      `
+      db.query(sqlQuery, (err, result) => {
+        if (err) return next(Boom.badImplementation(err))
+
+        user.policies = result.rows.map(mapping.policy.simple)
+        next()
+      })
+    })
+
+    async.series(tasks, (err) => {
       if (err) return cb(err)
-      let total = result.rows.length > 0 ? result.rows[0].total : 0
-      return cb(null, result.rows.map(mapping.user), total)
+
+      return cb(null, user)
+    })
+  },
+
+  /**
+   * Create a new user
+   *
+   * @param  {Object}   params { id, name, organizationId } "id" can be null
+   * @param  {Function} cb
+   */
+  createUser: function createUser (params, cb) {
+    const { id, name, organizationId } = params
+
+    Joi.validate({ id, name, organizationId }, validationRules.createUser, function (err) {
+      if (err) return cb(Boom.badRequest(err))
+
+      userOps.organizationExists(organizationId, (err, res) => {
+        if (err) return cb(Boom.badImplementation(err))
+        if (!res) return cb(Boom.badRequest(`Organization '${organizationId}' does not exists`))
+
+        userOps.insertUser(db, { id, name, organizationId }, (err, result) => {
+          if (err) return cb(err)
+
+          userOps.readUser({ id: result.rows[0].id, organizationId }, utils.boomErrorWrapper(cb))
+        })
+      })
+    })
+  },
+
+  /**
+   * Delete user
+   *
+   * @param  {Object}   { id, organizationId }
+   * @param  {Function} cb
+   */
+  deleteUser: function deleteUser (params, cb) {
+    const { id, organizationId } = params
+    const tasks = [
+      (job, next) => {
+        Joi.validate({ id, organizationId }, validationRules.deleteUser, (err) => {
+          if (err) return next(Boom.badRequest(err))
+
+          next()
+        })
+      },
+      (job, next) => {
+        job.id = id
+        next()
+      },
+      (job, next) => {
+        const sqlQuery = SQL`DELETE FROM user_policies WHERE user_id = ${id}`
+
+        job.client.query(sqlQuery, utils.boomErrorWrapper(next))
+      },
+      (job, next) => {
+        const sqlQuery = SQL`DELETE FROM team_members WHERE user_id = ${id}`
+
+        job.client.query(sqlQuery, utils.boomErrorWrapper(next))
+      },
+      (job, next) => {
+        const sqlQuery = SQL`DELETE FROM users WHERE id = ${id} AND org_id = ${organizationId}`
+
+        job.client.query(sqlQuery, (err, result) => {
+          if (err) return next(Boom.badImplementation(err))
+          if (result.rowCount === 0) return next(Boom.notFound(`User ${id} not found`))
+
+          next()
+        })
+      }
+    ]
+
+    db.withTransaction(tasks, (err, res) => {
+      if (err) return cb(err)
+
+      cb()
+    })
+  },
+
+  /**
+   * Update user details
+   *
+   * @param  {Object}   params { id, organizationId, name }
+   * @param  {Function} cb
+   */
+  updateUser: function updateUser (params, cb) {
+    const { id, organizationId, name } = params
+
+    Joi.validate({ id, organizationId, name }, validationRules.updateUser, function (err) {
+      if (err) return cb(Boom.badRequest(err))
+
+      const sqlQuery = SQL`
+        UPDATE users
+        SET name = ${name}
+        WHERE id = ${id}
+        AND org_id = ${organizationId}
+      `
+      db.query(sqlQuery, (err, result) => {
+        if (err) return cb(Boom.badImplementation(err))
+        if (result.rowCount === 0) return cb(Boom.notFound(`User ${id} not found`))
+
+        userOps.readUser({ id, organizationId }, cb)
+      })
+    })
+  },
+
+  /**
+   * Replace user poilicies
+   *
+   * @param  {Object}   params { id, organizationId, policies }
+   * @param  {Function} cb
+   */
+  replaceUserPolicies: function replaceUserPolicies (params, cb) {
+    const { id, organizationId, policies } = params
+    const tasks = [
+      (job, next) => {
+        Joi.validate({ id, organizationId, policies }, validationRules.replaceUserPolicies, (err) => {
+          if (err) return next(Boom.badRequest(err))
+
+          next()
+        })
+      },
+      (job, next) => {
+        job.id = id
+        job.organizationId = organizationId
+        job.policies = policies
+
+        next()
+      },
+      checkUserOrg,
+      clearUserPolicies
+    ]
+
+    if (policies.length > 0) {
+      tasks.push((job, next) => {
+        utils.checkPoliciesOrg(job.client, job.policies, job.organizationId, next)
+      })
+      tasks.push(insertUserPolicies)
+    }
+
+    db.withTransaction(tasks, (err, res) => {
+      if (err) {
+        return cb(err)
+      }
+
+      userOps.readUser({ id, organizationId }, cb)
+    })
+  },
+
+  /**
+   * Add one or more policies to a user
+   *
+   * @param  {Object}   params { id, organizationId, policies }
+   * @param  {Function} cb
+   */
+  addUserPolicies: function addUserPolicies (params, cb) {
+    const { id, organizationId, policies } = params
+    if (policies.length <= 0) {
+      return userOps.readUser({ id, organizationId }, cb)
+    }
+
+    const tasks = [
+      (job, next) => {
+        Joi.validate({ id, organizationId, policies }, validationRules.addUserPolicies, (err) => {
+          if (err) return next(Boom.badRequest(err))
+
+          next()
+        })
+      },
+      (job, next) => {
+        job.id = id
+        job.policies = policies
+        job.organizationId = organizationId
+
+        next()
+      },
+      checkUserOrg,
+      (job, next) => {
+        utils.checkPoliciesOrg(job.client, job.policies, job.organizationId, next)
+      },
+      insertUserPolicies
+    ]
+
+    db.withTransaction(tasks, (err, res) => {
+      if (err) return cb(err)
+
+      userOps.readUser({ id, organizationId }, cb)
+    })
+  },
+
+  /**
+   * Rmove all user's policies
+   *
+   * @param  {Object}   params { id, organizationId }
+   * @param  {Function} cb
+   */
+  deleteUserPolicies: function deleteUserPolicies (params, cb) {
+    const { id, organizationId } = params
+    const tasks = [
+      (job, next) => {
+        Joi.validate({ id, organizationId }, validationRules.deleteUserPolicies, (err) => {
+          if (err) return next(Boom.badRequest(err))
+
+          next()
+        })
+      },
+      (job, next) => {
+        job.id = id
+        job.organizationId = organizationId
+
+        next()
+      },
+      checkUserOrg,
+      clearUserPolicies
+    ]
+
+    db.withTransaction(tasks, (err, res) => {
+      if (err) {
+        return cb(err)
+      }
+
+      userOps.readUser({ id, organizationId }, cb)
+    })
+  },
+
+  /**
+   * Rmove all user's policies
+   *
+   * @param  {Object}   params { userId, organizationId, policyId }
+   * @param  {Function} cb
+   */
+  deleteUserPolicy: function deleteUserPolicy (params, cb) {
+    const { userId, organizationId, policyId } = params
+    const tasks = [
+      (job, next) => {
+        Joi.validate({ userId, organizationId, policyId }, validationRules.deleteUserPolicy, (err) => {
+          if (err) return next(Boom.badRequest(err))
+
+          next()
+        })
+      },
+      (job, next) => {
+        job.id = userId
+        job.policyId = policyId
+        job.organizationId = organizationId
+
+        next()
+      },
+      checkUserOrg,
+      removeUserPolicy
+    ]
+
+    db.withTransaction(tasks, (err, res) => {
+      if (err) {
+        return cb(err)
+      }
+
+      userOps.readUser({ id: userId, organizationId }, cb)
     })
   },
 
@@ -129,27 +473,6 @@ const userOps = {
   },
 
   /**
-   * Create a new user
-   *
-   * @param  {Object}   params { id, name, organizationId } "id" can be null
-   * @param  {Function} cb
-   */
-  createUser: function createUser (params, cb) {
-    const { id, name, organizationId } = params
-
-    userOps.organizationExists(organizationId, (err, res) => {
-      if (err) return cb(Boom.badImplementation(err))
-      if (!res) return cb(Boom.badRequest(`Organization '${organizationId}' does not exists`))
-
-      userOps.insertUser(db, { id, name, organizationId }, (err, result) => {
-        if (err) return cb(err)
-
-        userOps.readUser({ id: result.rows[0].id, organizationId }, utils.boomErrorWrapper(cb))
-      })
-    })
-  },
-
-  /**
    * Return the user organizationId
    *
    * @param  {Number}   id
@@ -167,264 +490,17 @@ const userOps = {
 
       return cb(null, result.rows[0].org_id)
     })
-  },
-
-  /**
-   * Get user details
-   *
-   * @param  {Object}   params { id, organizationId }
-   * @param  {Function} cb
-   */
-  readUser: function readUser (params, cb) {
-    const { id, organizationId } = params
-    let user
-
-    const tasks = []
-
-    tasks.push((next) => {
-      const sqlQuery = SQL`
-        SELECT id, name, org_id
-        FROM users
-        WHERE id = ${id}
-        AND org_id = ${organizationId}
-      `
-      db.query(sqlQuery, (err, result) => {
-        if (err) return next(Boom.badImplementation(err))
-        if (result.rowCount === 0) return next(Boom.notFound(`User ${id} not found`))
-
-        user = mapping.user(result.rows[0])
-        next()
-      })
-    })
-
-    tasks.push((next) => {
-      const sqlQuery = SQL`
-        SELECT teams.id, teams.name
-        FROM team_members mem, teams
-        WHERE mem.user_id = ${id} AND mem.team_id = teams.id
-        ORDER BY UPPER(teams.name)
-      `
-      db.query(sqlQuery, (err, result) => {
-        if (err) return next(Boom.badImplementation(err))
-
-        user.teams = result.rows.map(mapping.team.simple)
-        next()
-      })
-    })
-
-    tasks.push((next) => {
-      const sqlQuery = SQL`
-        SELECT pol.id, pol.name, pol.version
-        FROM user_policies user_pol, policies pol
-        WHERE user_pol.user_id = ${id} AND user_pol.policy_id = pol.id
-        ORDER BY UPPER(pol.name)
-      `
-      db.query(sqlQuery, (err, result) => {
-        if (err) return next(Boom.badImplementation(err))
-
-        user.policies = result.rows.map(mapping.policy.simple)
-        next()
-      })
-    })
-
-    async.series(tasks, (err) => {
-      if (err) return cb(err)
-
-      return cb(null, user)
-    })
-  },
-
-  /**
-   * Update user details
-   *
-   * @param  {Object}   params { id, organizationId, name }
-   * @param  {Function} cb
-   */
-  updateUser: function updateUser (params, cb) {
-    const { id, organizationId, name } = params
-
-    const sqlQuery = SQL`
-      UPDATE users
-      SET name = ${name}
-      WHERE id = ${id}
-      AND org_id = ${organizationId}
-    `
-    db.query(sqlQuery, (err, result) => {
-      if (err) return cb(Boom.badImplementation(err))
-      if (result.rowCount === 0) return cb(Boom.notFound(`User ${id} not found`))
-
-      userOps.readUser({ id, organizationId }, cb)
-    })
-  },
-
-  /**
-   * Replace user poilicies
-   *
-   * @param  {Object}   params { id, organizationId, policies }
-   * @param  {Function} cb
-   */
-  replaceUserPolicies: function replaceUserPolicies (params, cb) {
-    const { id, organizationId, policies } = params
-    const tasks = [
-      (job, next) => {
-        job.id = id
-        job.organizationId = organizationId
-        job.policies = policies
-
-        next()
-      },
-      checkUserOrg,
-      clearUserPolicies
-    ]
-
-    if (policies.length > 0) {
-      tasks.push((job, next) => {
-        utils.checkPoliciesOrg(job.client, job.policies, job.organizationId, next)
-      })
-      tasks.push(insertUserPolicies)
-    }
-
-    db.withTransaction(tasks, (err, res) => {
-      if (err) {
-        return cb(err)
-      }
-
-      userOps.readUser({ id, organizationId }, cb)
-    })
-  },
-
-  /**
-   * Add one or more policies to a user
-   *
-   * @param  {Object}   params { id, organizationId, policies }
-   * @param  {Function} cb
-   */
-  addUserPolicies: function addUserPolicies (params, cb) {
-    const { id, organizationId, policies } = params
-    if (policies.length <= 0) {
-      return userOps.readUser({ id, organizationId }, cb)
-    }
-
-    const tasks = [
-      (job, next) => {
-        job.id = id
-        job.policies = policies
-        job.organizationId = organizationId
-
-        next()
-      },
-      checkUserOrg,
-      (job, next) => {
-        utils.checkPoliciesOrg(job.client, job.policies, job.organizationId, next)
-      },
-      insertUserPolicies
-    ]
-
-    db.withTransaction(tasks, (err, res) => {
-      if (err) return cb(err)
-
-      userOps.readUser({ id, organizationId }, cb)
-    })
-  },
-
-  /**
-   * Rmove all user's policies
-   *
-   * @param  {Object}   params { id, organizationId }
-   * @param  {Function} cb
-   */
-  deleteUserPolicies: function deleteUserPolicies (params, cb) {
-    const { id, organizationId } = params
-    const tasks = [
-      (job, next) => {
-        job.id = id
-        job.organizationId = organizationId
-
-        next()
-      },
-      checkUserOrg,
-      clearUserPolicies
-    ]
-
-    db.withTransaction(tasks, (err, res) => {
-      if (err) {
-        return cb(err)
-      }
-
-      userOps.readUser({ id, organizationId }, cb)
-    })
-  },
-
-  /**
-   * Rmove all user's policies
-   *
-   * @param  {Object}   params { userId, organizationId, policyId }
-   * @param  {Function} cb
-   */
-  deleteUserPolicy: function deleteUserPolicy (params, cb) {
-    const { userId, organizationId, policyId } = params
-    const tasks = [
-      (job, next) => {
-        job.id = userId
-        job.policyId = policyId
-        job.organizationId = organizationId
-
-        next()
-      },
-      checkUserOrg,
-      removeUserPolicy
-    ]
-
-    db.withTransaction(tasks, (err, res) => {
-      if (err) {
-        return cb(err)
-      }
-
-      userOps.readUser({ id: userId, organizationId }, cb)
-    })
-  },
-
-  /**
-   * Delete user
-   *
-   * @param  {Object}   { id, organizationId }
-   * @param  {Function} cb
-   */
-  deleteUser: function deleteUser (params, cb) {
-    const { id, organizationId } = params
-    const tasks = [
-      (job, next) => {
-        job.id = id
-        next()
-      },
-      (job, next) => {
-        const sqlQuery = SQL`DELETE FROM user_policies WHERE user_id = ${id}`
-
-        job.client.query(sqlQuery, utils.boomErrorWrapper(next))
-      },
-      (job, next) => {
-        const sqlQuery = SQL`DELETE FROM team_members WHERE user_id = ${id}`
-
-        job.client.query(sqlQuery, utils.boomErrorWrapper(next))
-      },
-      (job, next) => {
-        const sqlQuery = SQL`DELETE FROM users WHERE id = ${id} AND org_id = ${organizationId}`
-
-        job.client.query(sqlQuery, (err, result) => {
-          if (err) return next(Boom.badImplementation(err))
-          if (result.rowCount === 0) return next(Boom.notFound(`User ${id} not found`))
-
-          next()
-        })
-      }
-    ]
-
-    db.withTransaction(tasks, (err, res) => {
-      if (err) return cb(err)
-
-      cb()
-    })
   }
 }
+
+userOps.listOrgUsers.validate = validationRules.listOrgUsers
+userOps.readUser.validate = validationRules.readUser
+userOps.createUser.validate = validationRules.createUser
+userOps.deleteUser.validate = validationRules.deleteUser
+userOps.updateUser.validate = validationRules.updateUser
+userOps.replaceUserPolicies.validate = validationRules.replaceUserPolicies
+userOps.addUserPolicies.validate = validationRules.addUserPolicies
+userOps.deleteUserPolicies.validate = validationRules.deleteUserPolicies
+userOps.deleteUserPolicy.validate = validationRules.deleteUserPolicy
 
 module.exports = userOps

--- a/src/lib/ops/validation.js
+++ b/src/lib/ops/validation.js
@@ -1,0 +1,233 @@
+'use strict'
+
+const Joi = require('joi')
+
+const requiredString = Joi.string().required()
+
+const validationRules = {
+  id: Joi.string().required(),
+  name: requiredString.description('Name'),
+  description: requiredString.description('Description'),
+  organizationId: requiredString.description('Organization ID'),
+  page: Joi.number().integer().min(1).description('Page number, starts from 1'),
+  limit: Joi.number().integer().min(1).description('Items per page'),
+  version: requiredString.description('Version number'),
+
+  user: Joi.object().description('Default admin').keys({
+    id: Joi.string().description('User ID'),
+    name: requiredString.description('User name')
+  }),
+
+  parentId: Joi.string().description('Parent ID'),
+  policyId: requiredString.description('Policy ID'),
+
+  users: Joi.array().required().items(requiredString).description('User IDs'),
+  policies: Joi.array().required().items(requiredString).description('Policies IDs'),
+
+  statements: Joi.object({
+    Statement: Joi.array().items(Joi.object({
+      Effect: Joi.string(),
+      Action: Joi.array().items(Joi.string()),
+      Resource: Joi.array().items(Joi.string()),
+      Sid: Joi.string(),
+      Condition: Joi.object()
+    }))
+  }).required().description('policy statements')
+
+}
+
+const users = {
+  listOrgUsers: {
+    page: validationRules.page,
+    limit: validationRules.limit,
+    organizationId: validationRules.organizationId
+  },
+  readUser: {
+    id: validationRules.id.description('User ID'),
+    organizationId: validationRules.organizationId
+  },
+  createUser: {
+    id: validationRules.id.optional().allow('').description('User ID'),
+    name: validationRules.name,
+    organizationId: validationRules.organizationId
+  },
+  deleteUser: {
+    id: validationRules.id.description('User ID'),
+    organizationId: validationRules.organizationId
+  },
+  updateUser: {
+    id: validationRules.id.description('User ID'),
+    name: validationRules.name,
+    organizationId: validationRules.organizationId
+  },
+  replaceUserPolicies: {
+    id: validationRules.id.description('User ID'),
+    policies: validationRules.policies,
+    organizationId: validationRules.organizationId
+  },
+  addUserPolicies: {
+    id: validationRules.id.description('User ID'),
+    policies: validationRules.policies,
+    organizationId: validationRules.organizationId
+  },
+  deleteUserPolicies: {
+    id: validationRules.id.description('User ID'),
+    organizationId: validationRules.organizationId
+  },
+  deleteUserPolicy: {
+    userId: validationRules.id.description('User ID'),
+    policyId: validationRules.policyId,
+    organizationId: validationRules.organizationId
+  }
+}
+
+const teams = {
+  listOrgTeams: {
+    page: validationRules.page,
+    limit: validationRules.limit,
+    organizationId: validationRules.organizationId
+  },
+  createTeam: {
+    id: Joi.string().regex(/^[0-9a-zA-Z_]+$/).allow('').description('The ID to be used for the new team. Only alphanumeric characters and underscore are supported'),
+    parentId: Joi.any(),
+    name: requiredString.description('Team name'),
+    description: validationRules.description,
+    user: validationRules.user,
+    organizationId: validationRules.organizationId
+  },
+  readTeam: {
+    id: validationRules.id.description('Team ID'),
+    organizationId: validationRules.organizationId
+  },
+  updateTeam: {
+    id: validationRules.id.description('Team ID'),
+    name: validationRules.name.optional(),
+    description: validationRules.description.optional(),
+    organizationId: validationRules.organizationId
+  },
+  deleteTeam: {
+    id: validationRules.id.description('Team ID'),
+    organizationId: validationRules.organizationId
+  },
+  moveTeam: {
+    id: validationRules.id.description('Team ID'),
+    parentId: validationRules.parentId,
+    organizationId: validationRules.organizationId
+  },
+  addTeamPolicies: {
+    id: validationRules.id.description('Team ID'),
+    policies: validationRules.policies,
+    organizationId: validationRules.organizationId
+  },
+  replaceTeamPolicies: {
+    id: validationRules.id.description('Team ID'),
+    policies: validationRules.policies,
+    organizationId: validationRules.organizationId
+  },
+  deleteTeamPolicies: {
+    id: validationRules.id.description('Team ID'),
+    organizationId: validationRules.organizationId
+  },
+  deleteTeamPolicy: {
+    teamId: validationRules.id.description('Team ID'),
+    policyId: validationRules.policyId,
+    organizationId: validationRules.organizationId
+  },
+  readTeamUsers: {
+    id: validationRules.id.description('Team ID'),
+    page: validationRules.page,
+    limit: validationRules.limit,
+    organizationId: validationRules.organizationId
+  },
+  addUsersToTeam: {
+    id: validationRules.id.description('Team ID'),
+    users: validationRules.users,
+    organizationId: validationRules.organizationId
+  },
+  replaceUsersInTeam: {
+    id: validationRules.id.description('Team ID'),
+    users: validationRules.users,
+    organizationId: validationRules.organizationId
+  },
+  deleteTeamMembers: {
+    id: validationRules.id.description('Team ID'),
+    organizationId: validationRules.organizationId
+  },
+  deleteTeamMember: {
+    id: validationRules.id.description('Team ID'),
+    userId: validationRules.id.description('User ID'),
+    organizationId: validationRules.organizationId
+  }
+}
+
+const policies = {
+  listByOrganization: {
+    organizationId: validationRules.organizationId,
+    page: validationRules.page,
+    limit: validationRules.limit
+  },
+  readPolicy: {
+    id: validationRules.id.description('Policy ID'),
+    organizationId: validationRules.organizationId
+  },
+  createPolicy: {
+    id: Joi.string().allow('').description('policy id'),
+    version: validationRules.version,
+    name: validationRules.name,
+    organizationId: validationRules.organizationId,
+    statements: validationRules.statements
+  },
+  updatePolicy: {
+    id: validationRules.id.description('Policy ID'),
+    organizationId: validationRules.organizationId,
+    version: validationRules.version,
+    name: validationRules.name,
+    statements: validationRules.statements
+  },
+  deletePolicy: {
+    id: validationRules.id.description('Policy ID'),
+    organizationId: validationRules.organizationId
+  }
+}
+
+const organizations = {
+  list: {
+    page: validationRules.page,
+    limit: validationRules.limit
+  },
+  readById: validationRules.organizationId,
+  create: {
+    id: Joi.string().regex(/^[a-zA-Z0-9]{1,64}$/).required().description('Organization ID'),
+    name: validationRules.name,
+    description: validationRules.description,
+    user: validationRules.user
+  },
+  deleteById: validationRules.organizationId,
+  update: {
+    id: validationRules.organizationId,
+    name: validationRules.name,
+    description: validationRules.description
+  }
+}
+
+const authorize = {
+  isUserAuthorized: {
+    userId: validationRules.id.description('User ID'),
+    action: requiredString.description('The action to check'),
+    resource: requiredString.description('The resource that the user wants to perform the action on'),
+    organizationId: validationRules.organizationId
+  },
+  listAuthorizations: {
+    userId: validationRules.id.description('User ID'),
+    resource: requiredString.description('The resource that the user wants to perform the action on'),
+    organizationId: validationRules.organizationId
+  }
+}
+
+module.exports = {
+  users,
+  teams,
+  policies,
+  organizations,
+  authorize
+}

--- a/src/routes/private/policies.js
+++ b/src/routes/private/policies.js
@@ -1,12 +1,13 @@
 'use strict'
 
+const _ = require('lodash')
 const Joi = require('joi')
 const Boom = require('boom')
 const serviceKey = require('./../../security/serviceKey')
 const Action = require('./../../lib/config/config.auth').Action
-const policyOps = require('./../../lib/ops/policyOps')
 const swagger = require('./../../swagger')
 const headers = require('./../headers')
+const udaru = require('./../../udaru')
 
 exports.register = function (server, options, next) {
 
@@ -27,7 +28,7 @@ exports.register = function (server, options, next) {
         statements
       }
 
-      policyOps.createPolicy(params, function (err, res) {
+      udaru.policies.create(params, function (err, res) {
         if (err) {
           return reply(err)
         }
@@ -37,12 +38,7 @@ exports.register = function (server, options, next) {
     },
     config: {
       validate: {
-        payload: {
-          id: Joi.string().allow('').description('Policy ID'),
-          version: Joi.string().required().description('Policy version'),
-          name: Joi.string().required().description('Policy name'),
-          statements: swagger.PolicyStatements.required().description('Policy statements')
-        },
+        payload: _.pick(udaru.policies.create.validate, ['id', 'name', 'version', 'statements']),
         query: {
           sig: Joi.string().required()
         },
@@ -78,18 +74,12 @@ exports.register = function (server, options, next) {
         statements
       }
 
-      policyOps.updatePolicy(params, reply)
+      udaru.policies.update(params, reply)
     },
     config: {
       validate: {
-        params: {
-          id: Joi.string().required().description('Policy ID')
-        },
-        payload: {
-          version: Joi.string().required().description('Policy version'),
-          name: Joi.string().required().description('Policy name'),
-          statements: swagger.PolicyStatements.required().description('Policy statements')
-        },
+        params: _.pick(udaru.policies.update.validate, ['id']),
+        payload: _.pick(udaru.policies.update.validate, ['version', 'name', 'statements']),
         query: {
           sig: Joi.string().required()
         },
@@ -117,7 +107,7 @@ exports.register = function (server, options, next) {
       const { id } = request.params
       const { organizationId } = request.udaru
 
-      policyOps.deletePolicy({ id, organizationId }, function (err, res) {
+      udaru.policies.delete({ id, organizationId }, function (err, res) {
         if (err) {
           return reply(err)
         }
@@ -127,9 +117,7 @@ exports.register = function (server, options, next) {
     },
     config: {
       validate: {
-        params: {
-          id: Joi.string().required().description('Policy ID')
-        },
+        params: _.pick(udaru.policies.delete.validate, ['id']),
         query: {
           sig: Joi.string().required()
         },

--- a/src/routes/public/authorization.js
+++ b/src/routes/public/authorization.js
@@ -1,8 +1,9 @@
 'use strict'
 
+const _ = require('lodash')
 const Joi = require('joi')
 const Action = require('./../../lib/config/config.auth').Action
-const authorize = require('./../../lib/ops/authorizeOps')
+const udaru = require('./../../udaru')
 const headers = require('./../headers')
 const swagger = require('./../../swagger')
 
@@ -22,7 +23,7 @@ exports.register = function (server, options, next) {
         organizationId
       }
 
-      authorize.isUserAuthorized(params, reply)
+      udaru.authorize.isUserAuthorized(params, reply)
     },
     config: {
       plugins: {
@@ -32,11 +33,7 @@ exports.register = function (server, options, next) {
         }
       },
       validate: {
-        params: {
-          userId: Joi.string().required().description('The user that wants to perform the action on a given resource'),
-          action: Joi.string().required().description('The action to check'),
-          resource: Joi.string().required().description('The resource that the user wants to perform the action on')
-        },
+        params: _.pick(udaru.authorize.isUserAuthorized.validate, ['userId', 'action', 'resource']),
         headers
       },
       description: 'Authorize user action against a resource',
@@ -58,7 +55,7 @@ exports.register = function (server, options, next) {
         organizationId
       }
 
-      authorize.listAuthorizations(params, reply)
+      udaru.authorize.listActions(params, reply)
     },
     config: {
       plugins: {
@@ -68,10 +65,7 @@ exports.register = function (server, options, next) {
         }
       },
       validate: {
-        params: {
-          userId: Joi.string().required().description('The user that wants to perform the action on a given resource'),
-          resource: Joi.string().required().description('The resource that the user wants to perform the action on')
-        },
+        params: _.pick(udaru.authorize.listActions.validate, ['userId', 'resource']),
         headers
       },
       description: 'List all the actions a user can perform on a resource',

--- a/src/routes/public/organizations.js
+++ b/src/routes/public/organizations.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const Joi = require('joi')
-const organizationOps = require('./../../lib/ops/organizationOps')
+const _ = require('lodash')
+const udaru = require('./../../udaru')
 const Action = require('./../../lib/config/config.auth').Action
 const conf = require('./../../lib/config')
 const swagger = require('./../../swagger')
@@ -15,7 +15,7 @@ exports.register = function (server, options, next) {
     handler: function (request, reply) {
       const limit = request.query.limit || conf.get('authorization.defaultPageSize')
       const page = request.query.page || 1
-      organizationOps.list({
+      udaru.organizations.list({
         limit: limit,
         page: page
       }, (err, data, total) => {
@@ -41,10 +41,7 @@ exports.register = function (server, options, next) {
       },
       validate: {
         headers,
-        query: Joi.object({
-          page: Joi.number().integer().min(1).description('Page number, starts from 1'),
-          limit: Joi.number().integer().min(1).description('Items per page')
-        }).required()
+        query: udaru.organizations.list.validate
       },
       response: {schema: swagger.List(swagger.Organization).label('PagedOrganizations')}
     }
@@ -54,7 +51,7 @@ exports.register = function (server, options, next) {
     method: 'GET',
     path: '/authorization/organizations/{id}',
     handler: function (request, reply) {
-      organizationOps.readById(request.params.id, reply)
+      udaru.organizations.read(request.params.id, reply)
     },
     config: {
       description: 'Get organization',
@@ -68,7 +65,7 @@ exports.register = function (server, options, next) {
       },
       validate: {
         params: {
-          id: Joi.string().required().description('Organization ID')
+          id: udaru.organizations.read.validate
         },
         headers
       },
@@ -87,7 +84,7 @@ exports.register = function (server, options, next) {
         user: request.payload.user
       }
 
-      organizationOps.create(params, function (err, res) {
+      udaru.organizations.create(params, function (err, res) {
         if (err) {
           return reply(err)
         }
@@ -97,15 +94,7 @@ exports.register = function (server, options, next) {
     },
     config: {
       validate: {
-        payload: {
-          id: Joi.string().regex(/^[a-zA-Z0-9]{1,64}$/).required().description('Organization ID'),
-          name: Joi.string().required().description('Organization name'),
-          description: Joi.string().required().description('Organization description'),
-          user: Joi.object().keys({
-            id: Joi.string().description('User ID'),
-            name: Joi.string().required().description('User name')
-          })
-        },
+        payload: udaru.organizations.create.validate,
         headers
       },
       description: 'Create an organization',
@@ -124,7 +113,7 @@ exports.register = function (server, options, next) {
     method: 'DELETE',
     path: '/authorization/organizations/{id}',
     handler: function (request, reply) {
-      organizationOps.deleteById(request.params.id, function (err, res) {
+      udaru.organizations.delete(request.params.id, function (err, res) {
         if (err) {
           return reply(err)
         }
@@ -144,7 +133,7 @@ exports.register = function (server, options, next) {
       },
       validate: {
         params: {
-          id: Joi.string().required().description('Organization ID')
+          id: udaru.organizations.delete.validate
         },
         headers
       }
@@ -158,17 +147,12 @@ exports.register = function (server, options, next) {
       const { id } = request.params
       const { name, description } = request.payload
 
-      organizationOps.update({id, name, description}, reply)
+      udaru.organizations.update({id, name, description}, reply)
     },
     config: {
       validate: {
-        params: {
-          id: Joi.string().required().description('organization ID')
-        },
-        payload: {
-          name: Joi.string().required().description('Organization name'),
-          description: Joi.string().required().description('Organization description')
-        },
+        params: _.pick(udaru.organizations.update.validate, ['id']),
+        payload: _.pick(udaru.organizations.update.validate, ['name', 'description']),
         headers
       },
       description: 'Update an organization',

--- a/src/routes/public/policies.js
+++ b/src/routes/public/policies.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const Joi = require('joi')
-const policyOps = require('./../../lib/ops/policyOps')
+const _ = require('lodash')
+const udaru = require('./../../udaru')
 const Action = require('./../../lib/config/config.auth').Action
 const conf = require('./../../lib/config')
 const swagger = require('./../../swagger')
@@ -15,7 +15,7 @@ exports.register = function (server, options, next) {
       const { organizationId } = request.udaru
       const limit = request.query.limit || conf.get('authorization.defaultPageSize')
       const page = request.query.page || 1
-      policyOps.listByOrganization({
+      udaru.policies.list({
         organizationId,
         limit: limit,
         page: page
@@ -42,10 +42,7 @@ exports.register = function (server, options, next) {
       },
       validate: {
         headers,
-        query: Joi.object({
-          page: Joi.number().integer().min(1).description('Page number, starts from 1'),
-          limit: Joi.number().integer().min(1).description('Items per page')
-        }).required()
+        query: _.pick(udaru.policies.list.validate, ['page', 'limit'])
       },
       response: {schema: swagger.List(swagger.Policy).label('PagedPolicies')}
     }
@@ -58,13 +55,11 @@ exports.register = function (server, options, next) {
       const { organizationId } = request.udaru
       const { id } = request.params
 
-      policyOps.readPolicy({ id, organizationId }, reply)
+      udaru.policies.read({ id, organizationId }, reply)
     },
     config: {
       validate: {
-        params: {
-          id: Joi.string().required().description('Policy ID')
-        },
+        params: _.pick(udaru.policies.read.validate, ['id']),
         headers
       },
       description: 'Fetch all the defined policies',

--- a/src/security/hapi-auth-validation.js
+++ b/src/security/hapi-auth-validation.js
@@ -38,8 +38,8 @@ function impersonate (job, next) {
   next()
 }
 
-function checkAuthorization (userId, action, resource, done) {
-  const params = { userId, action, resource }
+function checkAuthorization (userId, action, organizationId, resource, done) {
+  const params = { userId, action, organizationId, resource }
 
   authorizeOps.isUserAuthorized(params, (err, result) => {
     if (err) return done(err)
@@ -99,8 +99,9 @@ function authorize (job, next) {
 
     const action = job.authParams.action
     const userId = job.currentUser.id
+    const organizationId = job.organizationId
 
-    async.any(resources, async.apply(checkAuthorization, userId, action), (err, valid) => {
+    async.any(resources, async.apply(checkAuthorization, userId, action, organizationId), (err, valid) => {
       if (err) return next(Boom.forbidden('Invalid credentials', 'udaru'))
       if (!valid) return next(Boom.forbidden('Invalid credentials', 'udaru'))
 

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -69,7 +69,7 @@ const List = (data) => {
   return Joi.object({
     page: Joi.number().integer().min(1).description('Page number, starts from 1'),
     limit: Joi.number().integer().min(1).description('Items per page'),
-    total: Joi.number().integer().positive().description('Total number of entries matched by the query'),
+    total: Joi.number().integer().description('Total number of entries matched by the query'),
     data: Joi.array().items(data).label('Data')
   }).label('DataList')
 }

--- a/src/udaru.js
+++ b/src/udaru.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const userOps = require('./lib/ops/userOps')
+const organizationOps = require('./lib/ops/organizationOps')
+const authorizeOps = require('./lib/ops/authorizeOps')
+const teamOps = require('./lib/ops/teamOps')
+const policyOps = require('./lib/ops/policyOps')
+
+module.exports = {
+  authorize: {
+    isUserAuthorized: authorizeOps.isUserAuthorized,
+    listActions: authorizeOps.listAuthorizations
+  },
+
+  organizations: {
+    list: organizationOps.list,
+    create: organizationOps.create,
+    read: organizationOps.readById,
+    delete: organizationOps.deleteById,
+    update: organizationOps.update
+  },
+
+  policies: {
+    list: policyOps.listByOrganization,
+    read: policyOps.readPolicy,
+    create: policyOps.createPolicy,
+    update: policyOps.updatePolicy,
+    delete: policyOps.deletePolicy
+  },
+
+  teams: {
+    list: teamOps.listOrgTeams,
+    create: teamOps.createTeam,
+    read: teamOps.readTeam,
+    update: teamOps.updateTeam,
+    delete: teamOps.deleteTeam,
+    move: teamOps.moveTeam,
+    listUsers: teamOps.readTeamUsers,
+    replacePolicies: teamOps.replaceTeamPolicies,
+    addPolicies: teamOps.addTeamPolicies,
+    deletePolicies: teamOps.deleteTeamPolicies,
+    deletePolicy: teamOps.deleteTeamPolicy,
+    addUsers: teamOps.addUsersToTeam,
+    replaceUsers: teamOps.replaceUsersInTeam,
+    deleteMembers: teamOps.deleteTeamMembers,
+    deleteMember: teamOps.deleteTeamMember
+  },
+
+  users: {
+    list: userOps.listOrgUsers,
+    create: userOps.createUser,
+    read: userOps.readUser,
+    update: userOps.updateUser,
+    delete: userOps.deleteUser,
+    replacePolicies: userOps.replaceUserPolicies,
+    addPolicies: userOps.addUserPolicies,
+    deletePolicies: userOps.deleteUserPolicies,
+    deletePolicy: userOps.deleteUserPolicy
+  }
+}

--- a/test/endToEnd/authorization/usersTest.js
+++ b/test/endToEnd/authorization/usersTest.js
@@ -29,7 +29,7 @@ lab.experiment('Routes Authorizations', () => {
 
       const records = Factory(lab, {
         teams: {
-          calledTeam: { name: 'called team', organizationId, users: ['called'] }
+          calledTeam: { name: 'called team', description: 'desc', organizationId, users: ['called'] }
         },
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
@@ -101,7 +101,7 @@ lab.experiment('Routes Authorizations', () => {
 
       const records = Factory(lab, {
         teams: {
-          calledTeam: { name: 'called team', organizationId, users: ['called'] }
+          calledTeam: { name: 'called team', description: 'desc', organizationId, users: ['called'] }
         },
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
@@ -164,7 +164,7 @@ lab.experiment('Routes Authorizations', () => {
 
       const records = Factory(lab, {
         teams: {
-          calledTeam: { name: 'called team', organizationId }
+          calledTeam: { name: 'called team', description: 'desc', organizationId }
         },
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
@@ -229,7 +229,7 @@ lab.experiment('Routes Authorizations', () => {
 
       const records = Factory(lab, {
         teams: {
-          calledTeam: { name: 'called team', organizationId, users: ['called'] }
+          calledTeam: { name: 'called team', description: 'desc', organizationId, users: ['called'] }
         },
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
@@ -306,7 +306,7 @@ lab.experiment('Routes Authorizations', () => {
 
       const records = Factory(lab, {
         teams: {
-          calledTeam: { name: 'called team', organizationId, users: ['called'] }
+          calledTeam: { name: 'called team', description: 'desc', organizationId, users: ['called'] }
         },
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
@@ -380,7 +380,7 @@ lab.experiment('Routes Authorizations', () => {
 
       const records = Factory(lab, {
         teams: {
-          calledTeam: { name: 'called team', organizationId, users: ['called'] }
+          calledTeam: { name: 'called team', description: 'desc', organizationId, users: ['called'] }
         },
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
@@ -466,7 +466,7 @@ lab.experiment('Routes Authorizations', () => {
 
       const records = Factory(lab, {
         teams: {
-          calledTeam: { name: 'called team', organizationId, users: ['called'] }
+          calledTeam: { name: 'called team', description: 'desc', organizationId, users: ['called'] }
         },
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
@@ -552,7 +552,7 @@ lab.experiment('Routes Authorizations', () => {
 
       const records = Factory(lab, {
         teams: {
-          calledTeam: { name: 'called team', organizationId, users: ['called'] }
+          calledTeam: { name: 'called team', description: 'desc', organizationId, users: ['called'] }
         },
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
@@ -637,7 +637,7 @@ lab.experiment('Routes Authorizations', () => {
 
       const records = Factory(lab, {
         teams: {
-          calledTeam: { name: 'called team', organizationId, users: ['called'] }
+          calledTeam: { name: 'called team', description: 'desc', organizationId, users: ['called'] }
         },
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },

--- a/test/endToEnd/authorizationTest.js
+++ b/test/endToEnd/authorizationTest.js
@@ -15,6 +15,7 @@ lab.experiment('Authorization', () => {
 
     server.inject(options, (response) => {
       const result = response.result
+
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal({ access: true })
 

--- a/test/endToEnd/teamsTest.js
+++ b/test/endToEnd/teamsTest.js
@@ -18,7 +18,7 @@ const teamData = {
 
 lab.experiment('Teams - get/list', () => {
 
-  lab.test('get team list: pagination params are required', (done) => {
+  lab.test('get team list: with pagination params', (done) => {
     const options = utils.requestOptions({
       method: 'GET',
       url: '/authorization/teams'
@@ -28,6 +28,24 @@ lab.experiment('Teams - get/list', () => {
       expect(response.statusCode).to.equal(200)
       expect(response.result.page).to.equal(1)
       expect(response.result.limit).greaterThan(1)
+      done()
+    })
+  })
+
+  lab.test('get teams list from organization with no team', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/teams',
+      headers: {
+        authorization: 'ROOTid'
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(200)
+      expect(response.result.page).to.equal(1)
+      expect(response.result.limit).greaterThan(1)
+      expect(response.result.total).equal(0)
       done()
     })
   })
@@ -799,7 +817,7 @@ lab.experiment('Teams - manage policies', () => {
     server.inject(options, (response) => {
       expect(response.statusCode).to.equal(204)
 
-      teamOps.replaceTeamPolicies({ id: 1, policies: ['policyId1'], organizationId: 'WONKA' }, done)
+      teamOps.replaceTeamPolicies({ id: '1', policies: ['policyId1'], organizationId: 'WONKA' }, done)
     })
   })
 

--- a/test/endToEnd/usersTest.js
+++ b/test/endToEnd/usersTest.js
@@ -42,7 +42,7 @@ lab.experiment('Users: read - delete - update', () => {
   lab.test('get user list', (done) => {
     const options = utils.requestOptions({
       method: 'GET',
-      url: '/authorization/users?page=1&limit=123'
+      url: '/authorization/users?page=1&limit=3'
     })
 
     server.inject(options, (response) => {
@@ -51,7 +51,8 @@ lab.experiment('Users: read - delete - update', () => {
       expect(response.statusCode).to.equal(200)
       expect(result.total).to.equal(7)
       expect(result.page).to.equal(1)
-      expect(result.limit).to.equal(123)
+      expect(result.limit).to.equal(3)
+      expect(result.data.length).to.equal(3)
       expect(result.data[0]).to.equal({
         id: 'AugustusId',
         name: 'Augustus Gloop',
@@ -424,7 +425,7 @@ lab.experiment('Users - checking org_id scoping', () => {
       if (err) return done(err)
 
       const policyData = {
-        version: 1,
+        version: '1',
         name: 'Documents Admin',
         organizationId: 'NEWORG',
         statements

--- a/test/lib/integration/authorizeOpsTest.js
+++ b/test/lib/integration/authorizeOpsTest.js
@@ -71,7 +71,7 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('check authorization should return access true for allowed', (done) => {
-    authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'finance:ReadBalanceSheet' }, (err, result) => {
+    authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'finance:ReadBalanceSheet', organizationId }, (err, result) => {
       if (err) return done(err)
 
       expect(err).to.not.exist()
@@ -87,7 +87,7 @@ lab.experiment('AuthorizeOps', () => {
     userOps.replaceUserPolicies({ id: testUserId, policies: ['policyId5'], organizationId }, (err, result) => {
       if (err) return done(err)
 
-      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:dropTable' }, (err, result) => {
+      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:dropTable', organizationId }, (err, result) => {
         if (err) return done(err)
 
         expect(err).to.not.exist()
@@ -104,7 +104,7 @@ lab.experiment('AuthorizeOps', () => {
     userOps.replaceUserPolicies({ id: testUserId, policies: ['policyId6'], organizationId }, (err, result) => {
       if (err) return done(err)
 
-      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:Read' }, (err, result) => {
+      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:Read', organizationId }, (err, result) => {
         if (err) return done(err)
 
         expect(err).to.not.exist()
@@ -120,7 +120,7 @@ lab.experiment('AuthorizeOps', () => {
     userOps.replaceUserPolicies({ id: testUserId, policies: ['policyId7'], organizationId }, (err, result) => {
       if (err) return done(err)
 
-      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:Delete' }, (err, result) => {
+      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:Delete', organizationId }, (err, result) => {
         if (err) return done(err)
 
         expect(err).to.not.exist()
@@ -136,7 +136,7 @@ lab.experiment('AuthorizeOps', () => {
     userOps.replaceUserPolicies({ id: testUserId, policies: ['policyId8'], organizationId }, (err, result) => {
       if (err) return done(err)
 
-      authorize.isUserAuthorized({ userId: testUserId, resource: '/my/site/i/should/read/this', action: 'Read' }, (err, result) => {
+      authorize.isUserAuthorized({ userId: testUserId, resource: '/my/site/i/should/read/this', action: 'Read', organizationId }, (err, result) => {
         if (err) return done(err)
 
         expect(err).to.not.exist()
@@ -152,7 +152,7 @@ lab.experiment('AuthorizeOps', () => {
     userOps.replaceUserPolicies({ id: testUserId, policies: ['policyId6'], organizationId }, (err, result) => {
       if (err) return done(err)
 
-      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:Write' }, (err, result) => {
+      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:Write', organizationId }, (err, result) => {
         if (err) return done(err)
 
         expect(err).to.not.exist()
@@ -168,7 +168,7 @@ lab.experiment('AuthorizeOps', () => {
     userOps.replaceUserPolicies({ id: testUserId, policies: ['policyId6'], organizationId }, (err, result) => {
       if (err) return done(err)
 
-      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:notMyTable', action: 'database:Write' }, (err, result) => {
+      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:notMyTable', action: 'database:Write', organizationId }, (err, result) => {
         if (err) return done(err)
 
         expect(err).to.not.exist()
@@ -191,7 +191,7 @@ lab.experiment('AuthorizeOps', () => {
       testUtils.deleteUserFromAllTeams(testUserId, cb)
     })
     tasks.push((result, cb) => {
-      userOps.replaceUserPolicies({ id: testUserId, policies: [], organizationId }, cb)
+      userOps.deleteUserPolicies({ id: testUserId, organizationId }, cb)
     })
 
     tasks.push((result, cb) => {
@@ -219,7 +219,8 @@ lab.experiment('AuthorizeOps', () => {
     tasks.push((result, cb) => {
       authorize.listAuthorizations({
         userId: testUserId,
-        resource: 'database:pg01:balancesheet'
+        resource: 'database:pg01:balancesheet',
+        organizationId
       }, (err, result) => {
         expect(err).to.not.exist()
         expect(result).to.exist()
@@ -242,7 +243,8 @@ lab.experiment('AuthorizeOps', () => {
     tasks.push((result, cb) => {
       authorize.listAuthorizations({
         userId: testUserId,
-        resource: 'database:pg01:balancesheet'
+        resource: 'database:pg01:balancesheet',
+        organizationId
       }, (err, result) => {
         expect(err).to.not.exist()
         expect(result).to.exist()
@@ -267,7 +269,8 @@ lab.experiment('AuthorizeOps', () => {
     tasks.push((result, cb) => {
       authorize.listAuthorizations({
         userId: testUserId,
-        resource: 'database:pg01:balancesheet'
+        resource: 'database:pg01:balancesheet',
+        organizationId
       }, (err, result) => {
         expect(err).to.not.exist()
         expect(result).to.exist()
@@ -292,7 +295,8 @@ lab.experiment('AuthorizeOps', () => {
     tasks.push((result, cb) => {
       authorize.listAuthorizations({
         userId: testUserId,
-        resource: 'database:pg01:balancesheet'
+        resource: 'database:pg01:balancesheet',
+        organizationId
       }, (err, result) => {
         expect(err).to.not.exist()
         expect(result).to.exist()

--- a/test/lib/integration/organizationOpsTest.js
+++ b/test/lib/integration/organizationOpsTest.js
@@ -186,7 +186,7 @@ lab.experiment('OrganizationOps', () => {
   })
 
   lab.test('get a specific organization that does not exist', (done) => {
-    organizationOps.readById(['I_do_not_exist'], (err, result) => {
+    organizationOps.readById('I_do_not_exist', (err, result) => {
       expect(err).to.exist()
       expect(err.output.statusCode).to.equal(404)
       expect(result).to.not.exist()

--- a/test/lib/integration/policyOpsTest.js
+++ b/test/lib/integration/policyOpsTest.js
@@ -41,7 +41,7 @@ lab.experiment('PolicyOps', () => {
 
   lab.test('create, update and delete a policy', (done) => {
     const policyData = {
-      version: 1,
+      version: '1',
       name: 'Documents Admin',
       organizationId: 'WONKA',
       statements
@@ -60,7 +60,7 @@ lab.experiment('PolicyOps', () => {
       const updateData = {
         id: policyId,
         organizationId: 'WONKA',
-        version: 2,
+        version: '2',
         name: 'Documents Admin v2',
         statements: { Statement: [{ Effect: 'Deny', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*'] }] }
       }
@@ -81,7 +81,7 @@ lab.experiment('PolicyOps', () => {
   lab.test('create policy with specific id', (done) => {
     const policyData = {
       id: 'MySpecialId',
-      version: 1,
+      version: '1',
       name: 'Documents Admin',
       organizationId: 'WONKA',
       statements

--- a/test/lib/integration/teamOpsTest.js
+++ b/test/lib/integration/teamOpsTest.js
@@ -31,7 +31,7 @@ lab.experiment('TeamOps', () => {
       users = fetchedUsers
 
       policyOps.createPolicy({
-        version: 1,
+        version: '1',
         name: randomId(),
         organizationId: 'WONKA',
         statements
@@ -41,7 +41,7 @@ lab.experiment('TeamOps', () => {
         policies.push(createdPolicy)
 
         policyOps.createPolicy({
-          version: 1,
+          version: '1',
           name: randomId(),
           organizationId: 'WONKA',
           statements
@@ -52,7 +52,7 @@ lab.experiment('TeamOps', () => {
 
           policyOps.createPolicy({
             id: 'testPolicyId-1234',
-            version: 1,
+            version: '1',
             name: randomId(),
             organizationId: 'ROOT',
             statements
@@ -185,7 +185,7 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('read users from a specific team', (done) => {
-    teamOps.readTeamUsers({ id: '2' }, (err, result) => {
+    teamOps.readTeamUsers({ id: '2', organizationId: 'WONKA' }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
       expect(result.page).to.equal(1)
@@ -202,7 +202,7 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('paginated read users from a specific team', (done) => {
-    teamOps.readTeamUsers({ id: '2', page: 2, limit: 1 }, (err, result) => {
+    teamOps.readTeamUsers({ id: '2', page: 2, limit: 1, organizationId: 'WONKA' }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
       expect(result.page).to.equal(2)

--- a/test/routes/public/authorizationTest.js
+++ b/test/routes/public/authorizationTest.js
@@ -7,17 +7,19 @@ const Boom = require('boom')
 var proxyquire = require('proxyquire')
 var utils = require('./../../utils')
 
-var authorizeMock = {}
-var authRoutes = proxyquire('./../../../src/routes/public/authorization', { './../../lib/ops/authorizeOps': authorizeMock })
+var udaru = {}
+var authRoutes = proxyquire('./../../../src/routes/public/authorization', { './../../udaru': udaru })
 var server = proxyquire('./../../../src/wiring-hapi', { './routes/public/authorization': authRoutes })
 
 lab.experiment('Authorization', () => {
 
   lab.test('check authorization should return 500 for error case', (done) => {
-    authorizeMock.isUserAuthorized = (params, cb) => {
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.authorize = {
+      isUserAuthorized: (params, cb) => {
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({
@@ -35,10 +37,12 @@ lab.experiment('Authorization', () => {
   })
 
   lab.test('list authorizations should return 500 for error case', (done) => {
-    authorizeMock.listAuthorizations = (params, cb) => {
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.authorize = {
+      listActions: (params, cb) => {
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({

--- a/test/routes/public/policiesTest.js
+++ b/test/routes/public/policiesTest.js
@@ -7,19 +7,21 @@ const Boom = require('boom')
 var proxyquire = require('proxyquire')
 var utils = require('./../../utils')
 
-var policyOps = {}
-var policiesRoutes = proxyquire('./../../../src/routes/public/policies', { './../../lib/ops/policyOps': policyOps })
+var udaru = {}
+var policiesRoutes = proxyquire('./../../../src/routes/public/policies', { './../../udaru': udaru })
 var server = proxyquire('./../../../src/wiring-hapi', { './routes/public/policies': policiesRoutes })
 
 lab.experiment('Policies', () => {
 
   lab.test('get policy list should return error for error case', (done) => {
 
-    policyOps.listByOrganization = (params, cb) => {
-      expect(params).to.equal({ organizationId: 'WONKA', limit: 10, page: 1 })
-      setImmediate(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.policies = {
+      list: (params, cb) => {
+        expect(params).to.equal({ organizationId: 'WONKA', limit: 10, page: 1 })
+        setImmediate(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({
@@ -38,11 +40,13 @@ lab.experiment('Policies', () => {
   })
 
   lab.test('get single policy should return error for error case', (done) => {
-    policyOps.readPolicy = (params, cb) => {
-      expect(params).to.equal({ id: '99', organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.policies = {
+      read: (params, cb) => {
+        expect(params).to.equal({ id: '99', organizationId: 'WONKA' })
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({

--- a/test/routes/public/teamsTest.js
+++ b/test/routes/public/teamsTest.js
@@ -7,18 +7,20 @@ const Boom = require('boom')
 var proxyquire = require('proxyquire')
 var utils = require('./../../utils')
 
-var teamOps = {}
-var teamsRoutes = proxyquire('./../../../src/routes/public/teams', { './../../lib/ops/teamOps': teamOps })
+var udaru = {}
+var teamsRoutes = proxyquire('./../../../src/routes/public/teams', { './../../udaru': udaru })
 var server = proxyquire('./../../../src/wiring-hapi', { './routes/public/teams': teamsRoutes })
 
 lab.experiment('Teams', () => {
 
   lab.test('get team list should return error for error case', (done) => {
-    teamOps.listOrgTeams = (params, cb) => {
-      expect(params).to.equal({ organizationId: 'WONKA', limit: 1, page: 1 })
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.teams = {
+      list: (params, cb) => {
+        expect(params).to.equal({ organizationId: 'WONKA', limit: 1, page: 1 })
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({
@@ -38,10 +40,12 @@ lab.experiment('Teams', () => {
 
 
   lab.test('create new team should return error for error case', (done) => {
-    teamOps.createTeam = (params, cb) => {
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.teams = {
+      create: (params, cb) => {
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({
@@ -64,16 +68,18 @@ lab.experiment('Teams', () => {
   })
 
   lab.test('update team should return error for error case', (done) => {
-    teamOps.updateTeam = (params, cb) => {
-      expect(params).to.equal({
-        id: '2',
-        name: 'Team D',
-        description: 'Can Team C become Team D?',
-        organizationId: 'WONKA'
-      })
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.teams = {
+      update: (params, cb) => {
+        expect(params).to.equal({
+          id: '2',
+          name: 'Team D',
+          description: 'Can Team C become Team D?',
+          organizationId: 'WONKA'
+        })
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({
@@ -96,11 +102,13 @@ lab.experiment('Teams', () => {
   })
 
   lab.test('delete team should return error for error case', (done) => {
-    teamOps.deleteTeam = (params, cb) => {
-      expect(params).to.equal({ id: '1', organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.teams = {
+      delete: (params, cb) => {
+        expect(params).to.equal({ id: '1', organizationId: 'WONKA' })
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({

--- a/test/routes/public/usersTest.js
+++ b/test/routes/public/usersTest.js
@@ -7,18 +7,20 @@ const Boom = require('boom')
 var proxyquire = require('proxyquire')
 var utils = require('./../../utils')
 
-var userOps = {}
-var usersRoutes = proxyquire('./../../../src/routes/public/users', { './../../lib/ops/userOps': userOps })
+var udaru = {}
+var usersRoutes = proxyquire('./../../../src/routes/public/users', { './../../udaru': udaru })
 var server = proxyquire('./../../../src/wiring-hapi', { './routes/public/users': usersRoutes })
 
 lab.experiment('Users', () => {
 
   lab.test('get user list should return error for error case', (done) => {
-    userOps.listOrgUsers = function (params, cb) {
-      expect(params).to.equal({ organizationId: 'WONKA', limit: 100, page: 1 })
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.users = {
+      list: function (params, cb) {
+        expect(params).to.equal({ organizationId: 'WONKA', limit: 100, page: 1 })
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({
@@ -37,11 +39,13 @@ lab.experiment('Users', () => {
   })
 
   lab.test('get single user should return error for error case', (done) => {
-    userOps.readUser = function (params, cb) {
-      expect(params).to.equal({ id: 'Myid', organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.users = {
+      read: function (params, cb) {
+        expect(params).to.equal({ id: 'Myid', organizationId: 'WONKA' })
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({
@@ -60,10 +64,12 @@ lab.experiment('Users', () => {
   })
 
   lab.test('create user should return error for error case', (done) => {
-    userOps.createUser = function (params, cb) {
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.users = {
+      create: function (params, cb) {
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({
@@ -85,11 +91,13 @@ lab.experiment('Users', () => {
   })
 
   lab.test('delete user should return error for error case', (done) => {
-    userOps.deleteUser = function (params, cb) {
-      expect(params).to.equal({ id: 'MyId', organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.users = {
+      delete: function (params, cb) {
+        expect(params).to.equal({ id: 'MyId', organizationId: 'WONKA' })
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({
@@ -108,12 +116,14 @@ lab.experiment('Users', () => {
   })
 
   lab.test('update user should return error for error case', (done) => {
-    userOps.updateUser = function (params, cb) {
-      expect(params.id).to.equal('MyId')
-      expect(params.organizationId).to.equal('WONKA')
-      process.nextTick(() => {
-        cb(Boom.badImplementation())
-      })
+    udaru.users = {
+      update: function (params, cb) {
+        expect(params.id).to.equal('MyId')
+        expect(params.organizationId).to.equal('WONKA')
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
     }
 
     const options = utils.requestOptions({


### PR DESCRIPTION
Hi all,
this PR is a WIP for now and it's done to get some feedback.

I've created the `udaru` module and move the validation objects into the `ops` modules.

The validation is exposed to the routes through a `validate` property on each `udaru` function:

```
udaru.listOrganizations <=== function 
udaru.listOrganizations.validate <==== Joi object for validation
```

The most advanced of the modules is the [`userOps` module](https://github.com/nearform/labs-authorization/pull/319/files#diff-2e3e1b7134f3e2b71f7da05921880cef). 

In it I've:

- regrouped all the validation rules into an object
- added the validation inside the functions 
- added the property `validate` to each function

Next steps:

- do the same for the other ops modules
- create a single file for validation rules definition
- make ops module import that file and pick the validations they need

How does that sound? Any other feedback?

