### PR TITLE
Complete authentication tests

### DIFF
--- a/src/lib/config/config.auth.js
+++ b/src/lib/config/config.auth.js
@@ -6,7 +6,7 @@ const resourcesConfig = new Reconfig({
     organizations: '/{{ namespace }}/organization/[organizationId]',
     teams: '/{{ namespace }}/team/[organizationId]/[teamId]',
     users: '/{{ namespace }}/user/[organizationId]/[teamId]/[userId]',
-    policies: '/{{ namespace }}/policy/[organizationId]'
+    policies: '/{{ namespace }}/policy/[organizationId]/[policyId]'
   }
 }, {
   paramsInterpolation: ['[', ']'],

--- a/src/lib/ops/teamOps.js
+++ b/src/lib/ops/teamOps.js
@@ -107,11 +107,11 @@ function makeDefaultUserAdmin (job, next) {
 }
 
 function removeTeams (job, next) {
-  const { teamIds, organizationId } = job
+  const { teamId, teamIds, organizationId } = job
 
-  job.client.query(SQL`DELETE FROM teams WHERE id = ANY (${teamIds}) AND org_id = ${organizationId}`, (err, result) => {
+  job.client.query(SQL`DELETE FROM teams WHERE id = ANY (${teamIds}) AND org_id = ${organizationId} RETURNING id`, (err, result) => {
     if (err) return next(Boom.badImplementation(err))
-    if (result.rowCount !== teamIds.length) return next(Boom.notFound('Could not find all teams to be deleted'))
+    if (result.rows.map(getId).indexOf(teamId) < 0) return next(Boom.notFound(`Could not find team [${teamId}] to be deleted`))
     next()
   })
 }

--- a/src/routes/public/teams.js
+++ b/src/routes/public/teams.js
@@ -428,7 +428,7 @@ exports.register = function (server, options, next) {
       plugins: {
         auth: {
           action: Action.RemoveTeamPolicy,
-          getParams: (request) => ({ teamId: request.params.id })
+          getParams: (request) => ({ teamId: request.params.teamId })
         }
       }
     }

--- a/src/routes/public/teams.js
+++ b/src/routes/public/teams.js
@@ -222,7 +222,7 @@ exports.register = function (server, options, next) {
           return reply(err)
         }
 
-        return reply(res).code(201)
+        return reply(res).code(200)
       })
     },
     config: {
@@ -265,7 +265,7 @@ exports.register = function (server, options, next) {
           return reply(err)
         }
 
-        return reply(res).code(201)
+        return reply(res).code(200)
       })
     },
     config: {

--- a/test/endToEnd/authorization/policiesTest.js
+++ b/test/endToEnd/authorization/policiesTest.js
@@ -1,0 +1,311 @@
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+
+const server = require('../../../src/wiring-hapi')
+const config = require('../../../src/lib/config')
+const policyOps = require('../../../src/lib/ops/policyOps')
+
+const Factory = require('../../factory')
+const BuildFor = require('./testBuilder')
+
+const organizationId = 'WONKA'
+function Policy (Statement) {
+  return {
+    version: '2016-07-01',
+    name: 'Test Policy',
+    statements: JSON.stringify({
+      Statement: Statement || [{
+        Effect: 'Allow',
+        Action: ['dummy'],
+        Resource: ['dummy']
+      }]
+    }),
+    organizationId
+  }
+}
+
+lab.experiment('Routes Authorizations', () => {
+  lab.experiment('policies', () => {
+    lab.experiment('GET /authorization/policies', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'GET',
+          url: '/authorization/policies',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with correct policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:list'],
+          Resource: ['/authorization/policy/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/policy/WONKA']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:list'],
+          Resource: ['/authorization/policy/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('GET /authorization/policies/{id}', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy(),
+          calledPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'GET',
+          url: '/authorization/policies/{{calledPolicy.id}}',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all policies')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:read'],
+          Resource: ['/authorization/policy/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:read'],
+          Resource: ['/authorization/policy/WONKA/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/policy/WONKA/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:read'],
+          Resource: ['/authorization/policy/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('POST /authorization/policies', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'POST',
+          url: `/authorization/policies?sig=${config.get('security.api.servicekeys.private')}`,
+          payload: {
+            id: 'added-policy',
+            version: 'anything',
+            name: 'Added Policy',
+            statements: { Statement: [{
+              Effect: 'Allow',
+              Action: ['dummy'],
+              Resource: ['dummy']
+            }] }
+          },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      lab.afterEach((done) => {
+        policyOps.deletePolicy({ id: 'added-policy', organizationId: 'WONKA' }, () => {
+          // ignore error
+          done()
+        })
+      })
+
+      endpoint.test('should authorize user with correct policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:create'],
+          Resource: ['/authorization/policy/WONKA/*']
+        }])
+        .shouldRespond(201)
+
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/policy/WONKA/*']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:create'],
+          Resource: ['/authorization/policy/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('PUT /authorization/policies/{{id}}', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy(),
+          calledPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'PUT',
+          url: `/authorization/policies/{{calledPolicy.id}}?sig=${config.get('security.api.servicekeys.private')}`,
+          payload: {
+            version: 'anything',
+            name: 'Updated Policy',
+            statements: { Statement: [{
+              Effect: 'Allow',
+              Action: ['dummy'],
+              Resource: ['dummy']
+            }] }
+          },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all policies')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:update'],
+          Resource: ['/authorization/policy/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for a specific policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:update'],
+          Resource: ['/authorization/policy/WONKA/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(200)
+
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/policy/WONKA/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:update'],
+          Resource: ['/authorization/policy/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('DELETE /authorization/policies/{{id}}', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy(),
+          calledPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'DELETE',
+          url: `/authorization/policies/{{calledPolicy.id}}?sig=${config.get('security.api.servicekeys.private')}`,
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all policies')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:delete'],
+          Resource: ['/authorization/policy/WONKA/*']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should authorize user with policy for a specific policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:delete'],
+          Resource: ['/authorization/policy/WONKA/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(204)
+
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/policy/WONKA/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:delete'],
+          Resource: ['/authorization/policy/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+  })
+})

--- a/test/endToEnd/authorization/teamsTest.js
+++ b/test/endToEnd/authorization/teamsTest.js
@@ -1,0 +1,940 @@
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+
+const server = require('../../../src/wiring-hapi')
+const teamOps = require('../../../src/lib/ops/teamOps')
+
+const Factory = require('../../factory')
+const BuildFor = require('./testBuilder')
+
+const organizationId = 'WONKA'
+function Policy (Statement) {
+  return {
+    version: '2016-07-01',
+    name: 'Test Policy',
+    statements: JSON.stringify({
+      Statement: Statement || [{
+        Effect: 'Allow',
+        Action: ['dummy'],
+        Resource: ['dummy']
+      }]
+    }),
+    organizationId
+  }
+}
+
+lab.experiment('Routes Authorizations', () => {
+  lab.experiment('teams', () => {
+    lab.experiment('GET /authorization/teams', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'GET',
+          url: '/authorization/teams',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with correct policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:list'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:dummy'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:list'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('GET /authorization/teams/{id}', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'GET',
+          url: '/authorization/teams/{{calledTeam.id}}',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:read'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:read'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:read'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('POST /authorization/teams', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      lab.afterEach((done) => {
+        teamOps.deleteTeam({ id: 'created_team', organizationId }, () => {
+          // ignore error
+          done()
+        })
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'POST',
+          url: '/authorization/teams',
+          payload: {
+            id: 'created_team',
+            name: 'called team',
+            description: 'called team'
+          },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with correct policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:create'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(201)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:dummy'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:create'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('PUT /authorization/teams/{id}', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'PUT',
+          url: '/authorization/teams/{{calledTeam.id}}',
+          payload: {
+            name: 'updated team',
+            description: 'updated team'
+          },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:update'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:update'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:update'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('DELETE /authorization/teams/{id}', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'DELETE',
+          url: '/authorization/teams/{{calledTeam.id}}',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:delete'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:delete'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:delete'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('PUT /authorization/teams/{id}/nest', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId },
+          parentTeam: { name: 'parent team', description: 'parent team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'PUT',
+          url: '/authorization/teams/{{calledTeam.id}}/nest',
+          payload: { parentId: '{{parentTeam.id}}' },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:manage'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:manage'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:manage'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('PUT /authorization/teams/{id}/unnest', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId },
+          parentTeam: { name: 'parent team', description: 'parent team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'PUT',
+          url: '/authorization/teams/{{calledTeam.id}}/unnest',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:manage'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:manage'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:manage'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('PUT /authorization/teams/{id}/policies', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy(),
+          addedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'PUT',
+          url: '/authorization/teams/{{calledTeam.id}}/policies',
+          payload: { policies: ['{{addedPolicy.id}}'] },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:add'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:add'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:add'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('POST /authorization/teams/{id}/policies', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy(),
+          addedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'POST',
+          url: '/authorization/teams/{{calledTeam.id}}/policies',
+          payload: { policies: ['{{addedPolicy.id}}'] },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:replace'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:replace'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:replace'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('DELETE /authorization/teams/{id}/policies', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'DELETE',
+          url: '/authorization/teams/{{calledTeam.id}}/policies',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:remove'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:remove'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:remove'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('DELETE /authorization/teams/{id}/policies/{policyId}', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId, policies: ['deletedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy(),
+          deletedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'DELETE',
+          url: '/authorization/teams/{{calledTeam.id}}/policies/{{deletedPolicy.id}}',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:remove'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:remove'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:policy:remove'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('GET /authorization/teams/{id}/users', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
+          called: { name: 'called', organizationId, teams: ['calledTeam'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId, policies: ['deletedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy(),
+          deletedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'GET',
+          url: '/authorization/teams/{{calledTeam.id}}/users?page=1&limit=1',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:read'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:read'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:read'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('PUT /authorization/teams/{id}/users', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
+          member: { name: 'member', organizationId }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'PUT',
+          url: '/authorization/teams/{{calledTeam.id}}/users',
+          payload: { users: ['{{member.id}}'] },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:add'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:add'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:add'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('POST /authorization/teams/{id}/users', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
+          member: { name: 'member', organizationId }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy(),
+          addedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'POST',
+          url: '/authorization/teams/{{calledTeam.id}}/users',
+          payload: { users: ['{{member.id}}'] },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:replace'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:replace'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:replace'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('DELETE /authorization/teams/{id}/users', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
+          member: { name: 'member', organizationId, teams: ['calledTeam'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'DELETE',
+          url: '/authorization/teams/{{calledTeam.id}}/users',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:remove'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:remove'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:remove'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+    lab.experiment('DELETE /authorization/teams/{id}/users/{userId}', () => {
+
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
+          member: { name: 'member', organizationId, teams: ['calledTeam'] }
+        },
+        teams: {
+          calledTeam: { name: 'called team', description: 'called team', organizationId, policies: ['deletedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy(),
+          deletedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'DELETE',
+          url: '/authorization/teams/{{calledTeam.id}}/users/{{member.id}}',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all teams')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:remove'],
+          Resource: ['/authorization/team/WONKA/*']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should authorize user with policy for specific team')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:remove'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:dummy'],
+          Resource: ['/authorization/team/WONKA/{{calledTeam.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:teams:user:remove'],
+          Resource: ['/authorization/team/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+
+    })
+
+  })
+})

--- a/test/endToEnd/authorization/teamsTest.js
+++ b/test/endToEnd/authorization/teamsTest.js
@@ -651,10 +651,15 @@ lab.experiment('Routes Authorizations', () => {
       const records = Factory(lab, {
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
-          called: { name: 'called', organizationId, teams: ['calledTeam'] }
+          called: { name: 'called', organizationId }
         },
         teams: {
-          calledTeam: { name: 'called team', description: 'called team', organizationId, policies: ['deletedPolicy'] }
+          calledTeam: {
+            name: 'called team',
+            description: 'called team',
+            organizationId,
+            users: ['called']
+          }
         },
         policies: {
           testedPolicy: Policy(),
@@ -826,10 +831,10 @@ lab.experiment('Routes Authorizations', () => {
       const records = Factory(lab, {
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
-          member: { name: 'member', organizationId, teams: ['calledTeam'] }
+          member: { name: 'member', organizationId }
         },
         teams: {
-          calledTeam: { name: 'called team', description: 'called team', organizationId }
+          calledTeam: { name: 'called team', description: 'called team', organizationId, users: ['member'] }
         },
         policies: {
           testedPolicy: Policy()
@@ -883,10 +888,15 @@ lab.experiment('Routes Authorizations', () => {
       const records = Factory(lab, {
         users: {
           caller: { name: 'caller', organizationId, policies: ['testedPolicy'] },
-          member: { name: 'member', organizationId, teams: ['calledTeam'] }
+          member: { name: 'member', organizationId }
         },
         teams: {
-          calledTeam: { name: 'called team', description: 'called team', organizationId, policies: ['deletedPolicy'] }
+          calledTeam: {
+            name: 'called team',
+            description: 'called team',
+            organizationId,
+            users: ['member']
+          }
         },
         policies: {
           testedPolicy: Policy(),

--- a/test/endToEnd/teamsTest.js
+++ b/test/endToEnd/teamsTest.js
@@ -666,7 +666,7 @@ lab.experiment('Teams - nest/un-nest', () => {
     server.inject(options, (response) => {
       const { result } = response
 
-      expect(response.statusCode).to.equal(201)
+      expect(response.statusCode).to.equal(200)
       expect(result.path).to.equal('3.2')
 
       teamOps.moveTeam({ id: result.id, parentId: null, organizationId: result.organizationId }, done)
@@ -685,7 +685,7 @@ lab.experiment('Teams - nest/un-nest', () => {
       server.inject(options, (response) => {
         const { result } = response
 
-        expect(response.statusCode).to.equal(201)
+        expect(response.statusCode).to.equal(200)
         expect(result.path).to.equal('2')
 
         done()

--- a/test/lib/unit/configAuthTest.js
+++ b/test/lib/unit/configAuthTest.js
@@ -7,10 +7,11 @@ const lab = exports.lab = Lab.script()
 const configAuth = require('../../../src/lib/config/config.auth')
 
 lab.experiment('config.auth.js', () => {
-  let orgData = { organizationId: 'MyOrg' }
-  let TeamData = { organizationId: 'MyOrg', teamId: 'teamId' }
-  let UserData = { organizationId: 'MyOrg', teamId: 'teamId', userId: 'userId' }
-  let RandomData = { organizationId: 'MyOrg', teamId: 'teamId', userId: 'userId', random: 'random', data: 'data' }
+  const orgData = { organizationId: 'MyOrg' }
+  const TeamData = { organizationId: 'MyOrg', teamId: 'teamId' }
+  const UserData = { organizationId: 'MyOrg', teamId: 'teamId', userId: 'userId' }
+  const RandomData = { organizationId: 'MyOrg', teamId: 'teamId', userId: 'userId', random: 'random', data: 'data' }
+  const policyData = { organizationId: 'MyOrg', policyId: 'policyId' }
 
   lab.test('Resources - organization', (done) => {
     expect(configAuth.resources.organizations({})).to.equal('/authorization/organization/*')
@@ -46,11 +47,12 @@ lab.experiment('config.auth.js', () => {
 
   lab.test('Resources - policies', (done) => {
 
-    expect(configAuth.resources.policies({})).to.equal('/authorization/policy/*')
-    expect(configAuth.resources.policies(orgData)).to.equal('/authorization/policy/MyOrg')
-    expect(configAuth.resources.policies(TeamData)).to.equal('/authorization/policy/MyOrg')
-    expect(configAuth.resources.policies(UserData)).to.equal('/authorization/policy/MyOrg')
-    expect(configAuth.resources.policies(RandomData)).to.equal('/authorization/policy/MyOrg')
+    expect(configAuth.resources.policies({})).to.equal('/authorization/policy/*/*')
+    expect(configAuth.resources.policies(orgData)).to.equal('/authorization/policy/MyOrg/*')
+    expect(configAuth.resources.policies(policyData)).to.equal('/authorization/policy/MyOrg/policyId')
+    expect(configAuth.resources.policies(TeamData)).to.equal('/authorization/policy/MyOrg/*')
+    expect(configAuth.resources.policies(UserData)).to.equal('/authorization/policy/MyOrg/*')
+    expect(configAuth.resources.policies(RandomData)).to.equal('/authorization/policy/MyOrg/*')
 
     done()
   })


### PR DESCRIPTION
Included fixes:
- fix policies resource string template
- return error on delete team only if specific team is not found (ignore descendants), this solves a race conditions
- return status code 200 on nest and unnest instead of 201
- fix auth params for remove policy from team (it was returning the wrong parameter for teamId)

Fixes #240 