### PR TITLE
POST users, teams, orgs functionality unification

### DIFF
--- a/database/migrations/001.do.sql
+++ b/database/migrations/001.do.sql
@@ -6,7 +6,7 @@ CREATE EXTENSION ltree;
   probably GUID
  */
 CREATE TABLE organizations (
- id          VARCHAR(20) UNIQUE,
+ id          VARCHAR(128) UNIQUE,
  name        VARCHAR(64) NOT NULL,
  description VARCHAR(30)
 );

--- a/src/lib/ops/organizationOps.js
+++ b/src/lib/ops/organizationOps.js
@@ -9,6 +9,7 @@ const SQL = require('./../db/SQL')
 const mapping = require('./../mapping')
 const utils = require('./utils')
 const validationRules = require('./validation').organizations
+const uuid = require('uuid/v4')
 
 function fetchOrganizationUsers (job, next) {
   const { id } = job
@@ -75,6 +76,7 @@ function deleteOrganization (job, next) {
 
 function insertOrganization (job, next) {
   const { id, name, description } = job.params
+
   const sqlQuery = SQL`
     INSERT INTO organizations (
       id, name, description
@@ -200,7 +202,9 @@ var organizationOps = {
 
     const tasks = [
       (job, next) => {
-        const { id, name, description, user } = params
+        const id = params.id || uuid()
+        params.id = id
+        const { name, description, user } = params
 
         Joi.validate({ id, name, description, user }, validationRules.create, (err) => {
           if (err) return next(Boom.badRequest(err))

--- a/src/lib/ops/validation.js
+++ b/src/lib/ops/validation.js
@@ -47,7 +47,7 @@ const users = {
     organizationId: validationRules.organizationId
   },
   createUser: {
-    id: validationRules.id.optional().allow('').description('User ID'),
+    id: validationRules.id.optional().description('User ID'),
     name: validationRules.name,
     organizationId: validationRules.organizationId
   },
@@ -88,7 +88,7 @@ const teams = {
     organizationId: validationRules.organizationId
   },
   createTeam: {
-    id: Joi.string().regex(/^[0-9a-zA-Z_]+$/).allow('').description('The ID to be used for the new team. Only alphanumeric characters and underscore are supported'),
+    id: Joi.string().regex(/^[0-9a-zA-Z_]+$/).description('The ID to be used for the new team. Only alphanumeric characters and underscore are supported'),
     parentId: Joi.any(),
     name: requiredString.description('Team name'),
     description: validationRules.description,
@@ -197,7 +197,7 @@ const organizations = {
   },
   readById: validationRules.organizationId,
   create: {
-    id: Joi.string().regex(/^[a-zA-Z0-9]{1,64}$/).required().description('Organization ID'),
+    id: Joi.string().description('Organization ID'),
     name: validationRules.name,
     description: validationRules.description,
     user: validationRules.user

--- a/test/endToEnd/organizationsTest.js
+++ b/test/endToEnd/organizationsTest.js
@@ -186,6 +186,103 @@ lab.experiment('Organizations', () => {
     })
   })
 
+  lab.test('create organization with no id', (done) => {
+    const organization = {
+      name: 'nearForm',
+      description: 'nearForm org'
+    }
+
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/organizations',
+      payload: organization
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result.organization
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.id).to.not.be.null()
+      expect(result.name).to.equal(organization.name)
+      expect(result.description).to.equal(organization.description)
+
+      organizationOps.deleteById(result.id, done)
+    })
+  })
+
+  lab.test('create organization with specified but undefined id', (done) => {
+    const organization = {
+      id: undefined,
+      name: 'nearForm',
+      description: 'nearForm org'
+    }
+
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/organizations',
+      payload: organization
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result.organization
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.id).to.not.be.null()
+      expect(result.name).to.equal(organization.name)
+      expect(result.description).to.equal(organization.description)
+
+      organizationOps.deleteById(result.id, done)
+    })
+  })
+
+  lab.test('create organization with null id', (done) => {
+    const organization = {
+      id: null,
+      name: 'nearForm',
+      description: 'nearForm org'
+    }
+
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/organizations',
+      payload: organization
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(400)
+      expect(result.error).to.equal('Bad Request')
+      expect(result.id).to.not.exist()
+
+      done()
+    })
+  })
+
+  lab.test('create organization with empty string id', (done) => {
+    const organization = {
+      id: '',
+      name: 'nearForm',
+      description: 'nearForm org'
+    }
+
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/organizations',
+      payload: organization
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(400)
+      expect(result.error).to.equal('Bad Request')
+      expect(result.id).to.not.exist()
+
+      done()
+    })
+  })
+
   lab.test('create organization and an admin user should return 201 for success', (done) => {
     const organization = {
       id: 'nearForm',

--- a/test/endToEnd/teamsTest.js
+++ b/test/endToEnd/teamsTest.js
@@ -282,7 +282,7 @@ lab.experiment('Teams - get/list', () => {
 })
 
 lab.experiment('Teams - create', () => {
-  lab.test('default', (done) => {
+  lab.test('Create with no id', (done) => {
     const options = utils.requestOptions({
       method: 'POST',
       url: '/authorization/teams',
@@ -296,6 +296,7 @@ lab.experiment('Teams - create', () => {
       const result = response.result
 
       expect(response.statusCode).to.equal(201)
+      expect(result.id).to.not.be.null()
       expect(result).to.contain({
         name: 'Team B',
         organizationId: 'WONKA',
@@ -309,7 +310,36 @@ lab.experiment('Teams - create', () => {
     })
   })
 
-  lab.test('support specific id', (done) => {
+  lab.test('Create with undefined id', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/teams',
+      payload: {
+        id: undefined,
+        name: 'Team B',
+        description: 'This is Team B'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.id).to.not.be.null()
+      expect(result).to.contain({
+        name: 'Team B',
+        organizationId: 'WONKA',
+        description: 'This is Team B',
+        users: [],
+        policies: [],
+        path: result.id
+      })
+
+      teamOps.deleteTeam({ id: result.id, organizationId: result.organizationId }, done)
+    })
+  })
+
+  lab.test('Create with specific id', (done) => {
     const options = utils.requestOptions({
       method: 'POST',
       url: '/authorization/teams',
@@ -333,7 +363,7 @@ lab.experiment('Teams - create', () => {
     })
   })
 
-  lab.test('will not complain for empty id string', (done) => {
+  lab.test('create team with empty id string', (done) => {
     const options = utils.requestOptions({
       method: 'POST',
       url: '/authorization/teams',
@@ -347,10 +377,33 @@ lab.experiment('Teams - create', () => {
     server.inject(options, (response) => {
       const result = response.result
 
-      expect(response.statusCode).to.equal(201)
-      expect(result.id).to.not.equal('')
+      expect(response.statusCode).to.equal(400)
+      expect(result.error).to.equal('Bad Request')
+      expect(result.id).to.not.exist()
 
-      teamOps.deleteTeam({ id: result.id, organizationId: result.organizationId }, done)
+      done()
+    })
+  })
+
+  lab.test('create team with null id string', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/teams',
+      payload: {
+        id: null,
+        name: 'Team B',
+        description: 'This is Team B'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(400)
+      expect(result.error).to.equal('Bad Request')
+      expect(result.id).to.not.exist()
+
+      done()
     })
   })
 

--- a/test/endToEnd/usersTest.js
+++ b/test/endToEnd/usersTest.js
@@ -218,6 +218,82 @@ lab.experiment('Users - create', () => {
     })
   })
 
+  lab.test('create user for a specific organization being a SuperUser with a specified undefined user id', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users',
+      payload: {
+        id: undefined,
+        name: 'Salman'
+      },
+      headers: {
+        authorization: 'ROOTid',
+        org: 'OILCOUSA'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.id).to.not.be.null()
+      expect(result.name).to.equal('Salman')
+      expect(result.organizationId).to.equal('OILCOUSA')
+
+      userOps.deleteUser({ id: result.id, organizationId: 'OILCOUSA' }, done)
+    })
+  })
+
+  lab.test('create user for a specific organization being a SuperUser but with specifying empty string user id', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users',
+      payload: {
+        id: '',
+        name: 'Salman'
+      },
+      headers: {
+        authorization: 'ROOTid',
+        org: 'OILCOUSA'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(400)
+      expect(result.error).to.equal('Bad Request')
+      expect(result.id).to.not.exist()
+
+      done()
+    })
+  })
+
+  lab.test('create user for a specific organization being a SuperUser but with specifying null user id', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users',
+      payload: {
+        id: null,
+        name: 'Salman'
+      },
+      headers: {
+        authorization: 'ROOTid',
+        org: 'OILCOUSA'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(400)
+      expect(result.error).to.equal('Bad Request')
+      expect(result.id).to.not.exist()
+
+      done()
+    })
+  })
+
   lab.test('create user for a specific organization being a SuperUser with an already used id', (done) => {
     const options = utils.requestOptions({
       method: 'POST',


### PR DESCRIPTION
Implementation of https://github.com/nearform/labs-authorization/issues/324

Changes:
- Org, Teams and User creation endpoints can have in payload: id exists, id exists but is undefined, id does not exist (it is generated internally), **id as empty string is rejected**. Changed Joi validation according to these,
- Org creation have no regex limitations,
- the Org id in DB is changed to VARCHAR(128) - it was VARCHAR(20),
- Updated tests and added tests according to the changes above.