### PR TITLE
Update migration to fix problems for who was already using them

### DIFF
--- a/database/migrations/001.do.sql
+++ b/database/migrations/001.do.sql
@@ -20,6 +20,11 @@ CREATE TABLE policies (
   statements  JSONB
 );
 
+CREATE TABLE ref_actions (
+  action      VARCHAR(100) NOT NULL
+);
+
+/* TODO: users should have additional 'username' column */
 CREATE TABLE users (
   id        VARCHAR(128) UNIQUE,
   name      VARCHAR(50) NOT NULL,

--- a/database/migrations/002.do.sql
+++ b/database/migrations/002.do.sql
@@ -1,2 +1,4 @@
+DROP TABLE IF EXISTS ref_actions;
+
 ALTER TABLE organizations
   ALTER COLUMN id TYPE VARCHAR(128);


### PR DESCRIPTION
@marcopiraccini alerted us that postgrator is giving some errors when applying the new migrations. 

postgrator will create a md5 from each migration file and if we change it (spaces and such) it will complain 

ie:

```
verifying checksum of migration 001.do.sql
Error in runMigrations() while verifying checksums of existing migrations
Error: For migration [1], expected MD5 checksum [087575231b8a994ec3f1801e7b5c43b5] but got [58a6432ebb6890810f7ee97a6922399b]
```