### PR TITLE
invalid user policy id handling

### DIFF
--- a/lib/core/lib/ops/utils.js
+++ b/lib/core/lib/ops/utils.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _ = require('lodash')
 const Boom = require('boom')
 const SQL = require('./../db/SQL')
 
@@ -26,7 +27,7 @@ function checkPoliciesOrg (db, policies, organizationId, cb) {
     if (err) return cb(Boom.badImplementation(err))
 
     if (result.rowCount !== policies.length) {
-      return cb(Boom.badRequest(`Some policies [${policies.filter(p => result.rows.map(r => r.id).indexOf(p) < 0)}] were not found`))
+      return cb(Boom.badRequest(`Some policies [${_.difference(policies, result.rows.map(r => r.id))}] were not found`))
     }
 
     cb()
@@ -38,7 +39,7 @@ function checkUsersOrg (db, users, organizationId, cb) {
     if (err) return cb(Boom.badImplementation(err))
 
     if (result.rowCount !== users.length) {
-      return cb(Boom.badRequest(`Some users [${users.filter(p => result.rows.map(r => r.id).indexOf(p) < 0)}] were not found`))
+      return cb(Boom.badRequest(`Some users [${_.difference(users, result.rows.map(r => r.id))}] were not found`))
     }
 
     cb()
@@ -50,7 +51,7 @@ function checkTeamsOrg (db, teams, organizationId, cb) {
     if (err) return cb(Boom.badImplementation(err))
 
     if (result.rowCount !== teams.length) {
-      return cb(Boom.badRequest(`Some teams [${teams.filter(p => result.rows.map(r => r.id).indexOf(p) < 0)}] were not found`))
+      return cb(Boom.badRequest(`Some teams [${_.difference(teams, result.rows.map(r => r.id))}] were not found`))
     }
 
     cb()

--- a/lib/core/lib/ops/utils.js
+++ b/lib/core/lib/ops/utils.js
@@ -5,6 +5,10 @@ const SQL = require('./../db/SQL')
 
 function boomErrorWrapper (next) {
   return function wrapAsBadImplementation (err, result) {
+    if (err && err.isBoom) {
+      return next(err)
+    }
+
     next(err ? Boom.badImplementation(err) : null, result)
   }
 }
@@ -13,12 +17,16 @@ function isUniqueViolationError (err) {
   return err && err.code === '23505'
 }
 
+function isForeignKeyViolationError (err) {
+  return err && err.code === '23503'
+}
+
 function checkPoliciesOrg (db, policies, organizationId, cb) {
-  db.query(SQL`SELECT id FROM policies WHERE id = ANY (${policies}) AND org_id != ${organizationId}`, (err, result) => {
+  db.query(SQL`SELECT id FROM policies WHERE id = ANY (${policies}) AND org_id = ${organizationId}`, (err, result) => {
     if (err) return cb(Boom.badImplementation(err))
 
-    if (result.rowCount !== 0) {
-      return cb(Boom.badRequest(`Some policies [${result.rows.map(r => r.id).join(',')}] were not found`))
+    if (result.rowCount !== policies.length) {
+      return cb(Boom.badRequest(`Some policies [${policies.filter(p => result.rows.map(r => r.id).indexOf(p) < 0)}] were not found`))
     }
 
     cb()
@@ -26,11 +34,11 @@ function checkPoliciesOrg (db, policies, organizationId, cb) {
 }
 
 function checkUsersOrg (db, users, organizationId, cb) {
-  db.query(SQL`SELECT id FROM users WHERE id = ANY (${users}) AND org_id != ${organizationId}`, (err, result) => {
+  db.query(SQL`SELECT id FROM users WHERE id = ANY (${users}) AND org_id = ${organizationId}`, (err, result) => {
     if (err) return cb(Boom.badImplementation(err))
 
-    if (result.rowCount !== 0) {
-      return cb(Boom.badRequest(`Some users [${result.rows.map(r => r.id).join(',')}] were not found`))
+    if (result.rowCount !== users.length) {
+      return cb(Boom.badRequest(`Some users [${users.filter(p => result.rows.map(r => r.id).indexOf(p) < 0)}] were not found`))
     }
 
     cb()
@@ -38,11 +46,11 @@ function checkUsersOrg (db, users, organizationId, cb) {
 }
 
 function checkTeamsOrg (db, teams, organizationId, cb) {
-  db.query(SQL`SELECT id FROM teams WHERE id = ANY (${teams}) AND org_id != ${organizationId}`, (err, result) => {
+  db.query(SQL`SELECT id FROM teams WHERE id = ANY (${teams}) AND org_id = ${organizationId}`, (err, result) => {
     if (err) return cb(Boom.badImplementation(err))
 
-    if (result.rowCount !== 0) {
-      return cb(Boom.badRequest(`Some teams [${result.rows.map(r => r.id).join(',')}] were not found`))
+    if (result.rowCount !== teams.length) {
+      return cb(Boom.badRequest(`Some teams [${teams.filter(p => result.rows.map(r => r.id).indexOf(p) < 0)}] were not found`))
     }
 
     cb()
@@ -64,6 +72,7 @@ function checkUserOrg (db, id, organizationId, cb) {
 module.exports = {
   boomErrorWrapper,
   isUniqueViolationError,
+  isForeignKeyViolationError,
   checkPoliciesOrg,
   checkUsersOrg,
   checkTeamsOrg,

--- a/test/integration/endToEnd/teams.test.js
+++ b/test/integration/endToEnd/teams.test.js
@@ -785,6 +785,21 @@ lab.experiment('Teams - manage policies', () => {
     })
   })
 
+  lab.test('Add to one team a policy with invalid ID should return an error', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/teams/1/policies',
+      payload: {
+        policies: ['InvalidID']
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      done()
+    })
+  })
+
   lab.test('Add one policy from another org to a team should return an error', (done) => {
     const options = utils.requestOptions({
       method: 'PUT',
@@ -840,6 +855,21 @@ lab.experiment('Teams - manage policies', () => {
       expect(result.policies).to.equal([{ id: 'policyId6', name: 'DB Only Read', version: '0.1' }])
 
       udaru.teams.replacePolicies({ id: result.id, policies: ['policyId1'], organizationId: result.organizationId }, done)
+    })
+  })
+
+  lab.test('Replace team policies with a policy with invalid ID should return an error', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/teams/1/policies',
+      payload: {
+        policies: ['InvalidID']
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      done()
     })
   })
 
@@ -905,6 +935,21 @@ lab.experiment('Teams - checking org_id scoping', () => {
     udaru.organizations.delete('NEWORG', done)
   })
 
+  lab.test('Adding a user with invalid ID should not be permitted', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/teams/2/users',
+      payload: {
+        users: ['invalidUserId']
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      done()
+    })
+  })
+
   lab.test('Adding a user from another organization should not be permitted', (done) => {
     const options = utils.requestOptions({
       method: 'PUT',
@@ -926,6 +971,21 @@ lab.experiment('Teams - checking org_id scoping', () => {
       url: '/authorization/teams/2/users',
       payload: {
         users: ['testUserId', 'MikeId']
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      done()
+    })
+  })
+
+  lab.test('Adding a user with invalid ID should not be permitted', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/teams/2/users',
+      payload: {
+        users: ['InvalidUserId']
       }
     })
 

--- a/test/integration/endToEnd/users.test.js
+++ b/test/integration/endToEnd/users.test.js
@@ -390,6 +390,36 @@ lab.experiment('Users - manage policies', () => {
     })
   })
 
+  lab.test('add policy with invalid ID to a user', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/users/ModifyId/policies',
+      payload: {
+        policies: ['InvalidPolicyID']
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      done()
+    })
+  })
+
+  lab.test('replace policies with a policy with invalid ID should return an error', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users/ModifyId/policies',
+      payload: {
+        policies: ['InvalidPolicyID']
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      done()
+    })
+  })
+
   lab.test('clear and replace policies for a user', (done) => {
     udaru.policies.create(policyCreateData, (err, p) => {
       expect(err).to.not.exist()

--- a/test/integration/teamOps.test.js
+++ b/test/integration/teamOps.test.js
@@ -369,7 +369,21 @@ lab.experiment('TeamOps', () => {
     })
   })
 
-  lab.test('moveTeam should return an erro if teams arre from different orgs', (done) => {
+  lab.test('moveTeam should return an error if the moved team has invalid ID', (done) => {
+    const id = 'InvalidMoveID'
+    const parentId = 'InvalidParentMoveID'
+    udaru.teams.move({ id: id, parentId: parentId, organizationId: 'WONKA' }, (err, result) => {
+      expect(err).to.exist()
+      expect(err.message).to.include('Some teams')
+      expect(err.message).to.include('were not found')
+      expect(err.message).to.include(id)
+      expect(err.message).to.include(parentId)
+
+      done()
+    })
+  })
+
+  lab.test('moveTeam should return an error if teams are from different orgs', (done) => {
     let childTeam = {
       id: 'childTeam',
       name: 'Team Child',


### PR DESCRIPTION
The PR fixes the foreign key returned error for cases when the ID is invalid for operations like add policy, user, replace policy, replace user