### PR TITLE
Add two new users endpoint replace/delete teams

### DIFF
--- a/database/init.js
+++ b/database/init.js
@@ -25,7 +25,7 @@ function connect (next) {
 
 function dropDb (next) {
   client.query(`DROP DATABASE IF EXISTS "${config.get('pgdb.database')}"`, function (err, result) {
-    if (err) throw next(err)
+    if (err) return next(err)
 
     next()
   })
@@ -33,7 +33,7 @@ function dropDb (next) {
 
 function createDb (next) {
   client.query(`CREATE DATABASE "${config.get('pgdb.database')}"`, function (err, result) {
-    if (err) throw next(err)
+    if (err) return next(err)
 
     next()
   })
@@ -41,7 +41,7 @@ function createDb (next) {
 
 function dropAdminUser (next) {
   client.query('DROP USER IF EXISTS "admin"', function (err, result) {
-    if (err) throw next(err)
+    if (err) return next(err)
 
     next()
   })
@@ -49,7 +49,7 @@ function dropAdminUser (next) {
 
 function createAdminUser (next) {
   client.query('CREATE USER "admin" WITH PASSWORD \'default\'', function (err, result) {
-    if (err) throw next(err)
+    if (err) return next(err)
 
     next()
   })

--- a/database/testdata/fixtures.sql
+++ b/database/testdata/fixtures.sql
@@ -39,7 +39,7 @@ VALUES
   (2, 'Readers', 'General read-only access', NULL, 'WONKA', TEXT2LTREE('2')),
   (3, 'Authors', 'Content contributors', NULL, 'WONKA', TEXT2LTREE('3')),
   (4, 'Managers', 'General Line Managers with confidential info', NULL, 'WONKA', TEXT2LTREE('4'));
-  
+
 INSERT INTO teams (id, name, description, team_parent_id, org_id, path)
   SELECT 5, 'Personnel Managers', 'Personnel Line Managers with confidential info', id, 'WONKA', TEXT2LTREE('5') FROM teams WHERE name = 'Managers'
 UNION
@@ -211,7 +211,7 @@ UNION
 
 
 INSERT INTO team_policies
-  SELECT t.id, p.id 
+  SELECT t.id, p.id
   FROM teams AS t
   INNER JOIN policies AS p
     ON  p.name = 'Director'

--- a/lib/core/config/config.auth.js
+++ b/lib/core/config/config.auth.js
@@ -46,6 +46,8 @@ const Actions = {
   AddUserPolicy: 'authorization:users:policy:add',
   ReplaceUserPolicy: 'authorization:users:policy:replace',
   RemoveUserPolicy: 'authorization:users:policy:remove',
+  ReplaceUserTeams: 'authorization:users:teams:replace',
+  DeleteUserTeams: 'authorization:users:teams:remove',
   AllUser: 'authorization:users:*',
 
   // policy

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -59,6 +59,8 @@ module.exports = {
     replacePolicies: userOps.replaceUserPolicies,
     addPolicies: userOps.addUserPolicies,
     deletePolicies: userOps.deleteUserPolicies,
-    deletePolicy: userOps.deleteUserPolicy
+    deletePolicy: userOps.deleteUserPolicy,
+    replaceTeams: userOps.replaceUserTeams,
+    deleteTeams: userOps.deleteUserFromTeams
   }
 }

--- a/lib/core/lib/ops/userOps.js
+++ b/lib/core/lib/ops/userOps.js
@@ -20,6 +20,16 @@ function clearUserPolicies (job, next) {
   job.client.query(sqlQuery, utils.boomErrorWrapper(next))
 }
 
+function clearUserTeams (job, next) {
+  const { id } = job
+
+  const sqlQuery = SQL`
+    DELETE FROM team_members
+    WHERE user_id = ${id}
+  `
+  job.client.query(sqlQuery, utils.boomErrorWrapper(next))
+}
+
 function removeUserPolicy (job, next) {
   const { id, policyId } = job
 
@@ -41,6 +51,12 @@ function insertUserPolicies (job, next) {
   const { id: userId, policies } = job
 
   userOps.insertPolicies(job.client, userId, policies, utils.boomErrorWrapper(next))
+}
+
+function insertUserTeams (job, next) {
+  const { id: userId, teams } = job
+
+  userOps.insertTeams(job.client, userId, teams, utils.boomErrorWrapper(next))
 }
 
 const userOps = {
@@ -444,6 +460,21 @@ const userOps = {
     })
   },
 
+  insertTeams: function insertTeams (client, id, teams, cb) {
+    const sqlQuery = SQL`
+      INSERT INTO team_members (
+        team_id, user_id
+      ) VALUES
+    `
+    sqlQuery.append(SQL`(${teams[0]}, ${id})`)
+    teams.slice(1).forEach((policyId) => {
+      sqlQuery.append(SQL`, (${policyId}, ${id})`)
+    })
+    sqlQuery.append(SQL` ON CONFLICT ON CONSTRAINT team_member_link DO NOTHING`)
+
+    client.query(sqlQuery, utils.boomErrorWrapper(cb))
+  },
+
   insertPolicies: function insertPolicies (client, id, policies, cb) {
     const sqlQuery = SQL`
       INSERT INTO user_policies (
@@ -490,6 +521,81 @@ const userOps = {
 
       return cb(null, result.rows[0].org_id)
     })
+  },
+
+  /**
+   * Return the user organizationId
+   *
+   * @param  {Object}   params { id, teams, organizationId }
+   * @param  {Function} cb
+   */
+  replaceUserTeams: function replaceUserTeams (params, cb) {
+    const { id, organizationId, teams } = params
+    const tasks = [
+      (job, next) => {
+        Joi.validate({ id, organizationId, teams }, validationRules.replaceUserTeams, (err) => {
+          if (err) return next(Boom.badRequest(err))
+
+          next()
+        })
+      },
+      (job, next) => {
+        job.id = id
+        job.organizationId = organizationId
+        job.teams = teams
+
+        next()
+      },
+      checkUserOrg,
+      (job, next) => {
+        utils.checkTeamsOrg(job.client, job.teams, job.organizationId, next)
+      },
+      clearUserTeams,
+      insertUserTeams
+    ]
+
+    db.withTransaction(tasks, (err, res) => {
+      if (err) {
+        return cb(err)
+      }
+
+      userOps.readUser({ id, organizationId }, cb)
+    })
+  },
+
+  /**
+   * Return the user organizationId
+   *
+   * @param  {Object}   params { id, organizationId }
+   * @param  {Function} cb
+   */
+  deleteUserFromTeams: function deleteUserFromTeams (params, cb) {
+    const { id, organizationId } = params
+    const tasks = [
+      (job, next) => {
+        Joi.validate({ id, organizationId }, validationRules.deleteUserFromTeams, (err) => {
+          if (err) return next(Boom.badRequest(err))
+
+          next()
+        })
+      },
+      (job, next) => {
+        job.id = id
+        job.organizationId = organizationId
+
+        next()
+      },
+      checkUserOrg,
+      clearUserTeams
+    ]
+
+    db.withTransaction(tasks, (err, res) => {
+      if (err) {
+        return cb(err)
+      }
+
+      userOps.readUser({ id, organizationId }, cb)
+    })
   }
 }
 
@@ -502,5 +608,7 @@ userOps.replaceUserPolicies.validate = validationRules.replaceUserPolicies
 userOps.addUserPolicies.validate = validationRules.addUserPolicies
 userOps.deleteUserPolicies.validate = validationRules.deleteUserPolicies
 userOps.deleteUserPolicy.validate = validationRules.deleteUserPolicy
+userOps.replaceUserTeams.validate = validationRules.replaceUserTeams
+userOps.deleteUserFromTeams.validate = validationRules.deleteUserFromTeams
 
 module.exports = userOps

--- a/lib/core/lib/ops/validation.js
+++ b/lib/core/lib/ops/validation.js
@@ -23,6 +23,7 @@ const validationRules = {
 
   users: Joi.array().required().items(requiredString).description('User IDs'),
   policies: Joi.array().required().items(requiredString).description('Policies IDs'),
+  teams: Joi.array().required().items(requiredString).description('Teams IDs'),
 
   statements: Joi.object({
     Statement: Joi.array().items(Joi.object({
@@ -77,6 +78,15 @@ const users = {
   deleteUserPolicy: {
     userId: validationRules.id.description('User ID'),
     policyId: validationRules.policyId,
+    organizationId: validationRules.organizationId
+  },
+  replaceUserTeams: {
+    id: validationRules.id.description('User ID'),
+    teams: validationRules.teams,
+    organizationId: validationRules.organizationId
+  },
+  deleteUserFromTeams: {
+    id: validationRules.id.description('User ID'),
     organizationId: validationRules.organizationId
   }
 }

--- a/lib/plugin/routes/public/users.js
+++ b/lib/plugin/routes/public/users.js
@@ -307,6 +307,73 @@ exports.register = function (server, options, next) {
     }
   })
 
+  server.route({
+    method: 'POST',
+    path: '/authorization/users/{id}/teams',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { teams } = request.payload
+
+      const params = {
+        id,
+        organizationId,
+        teams
+      }
+
+      udaru.users.replaceTeams(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(udaru.users.replaceTeams.validate, ['id']),
+        payload: _.pick(udaru.users.replaceTeams.validate, ['teams']),
+        headers
+      },
+      description: 'Clear and replace user teams',
+      notes: 'The POST /authorization/users/{id}/teams endpoint replaces all the user teams. This can be use to move a user from a team to another (or a set of teams to another).\n',
+      tags: ['api', 'service', 'post', 'users', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.ReplaceUserTeams,
+          getParams: (request) => ({ userId: request.params.id })
+        }
+      },
+      response: {schema: swagger.User}
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/users/{id}/teams',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+
+      const params = {
+        id,
+        organizationId
+      }
+
+      udaru.users.deleteTeams(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(udaru.users.deleteTeams.validate, ['id']),
+        headers
+      },
+      description: 'Delete teams for a user',
+      notes: 'The DELETE /authorization/users/{id}/teams endpoint deletes user from all her teams.\n',
+      tags: ['api', 'service', 'post', 'users', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.DeleteUserTeams,
+          getParams: (request) => ({ userId: request.params.id })
+        }
+      },
+      response: {schema: swagger.User}
+    }
+  })
+
   next()
 }
 

--- a/lib/plugin/security/authorization.js
+++ b/lib/plugin/security/authorization.js
@@ -1,0 +1,114 @@
+'use strict'
+
+const _ = require('lodash')
+const Boom = require('boom')
+const async = require('async')
+const config = require('../config')
+
+const Action = config.get('AuthConfig.Action')
+const actionsNeedingValidation = [Action.ReplaceUserTeams, Action.DeleteUserTeams]
+
+function getAuthParams (request) {
+  return request.route.settings.plugins && request.route.settings.plugins.auth
+}
+
+function getTeams (server, request, callback) {
+  const authParams = getAuthParams(request)
+  if (!authParams || !authParams.action) {
+    return callback(Boom.forbidden('Invalid credentials', 'udaru'))
+  }
+
+  if (Action.ReplaceUserTeams === authParams.action) {
+    return callback(null, _.get(request, 'payload.teams'))
+  }
+
+  if (Action.DeleteUserTeams === authParams.action) {
+    const { user: currentUser } = request.udaru
+    if (!currentUser) {
+      return callback(Boom.forbidden('Invalid credentials', 'udaru'))
+    }
+
+    const requestParams = authParams.getParams ? authParams.getParams(request) : {}
+    const organizationId = request.headers.org || currentUser.organizationId
+
+    server.app.udaru.users.read({ id: requestParams.userId, organizationId }, function (err, user) {
+      if (err) return callback(err)
+
+      return callback(null, user.teams.map(t => t.id))
+    })
+  }
+}
+
+function needTeamsValidation (request) {
+  const authParams = getAuthParams(request)
+
+  if (!authParams) {
+    return false
+  }
+
+  return _.includes(actionsNeedingValidation, authParams.action)
+}
+
+function validateTeamsInPayload (server, request, reply) {
+  getTeams(server, request, function (err, teams) {
+    if (err) return reply(err)
+
+    const { user: currentUser } = request.udaru
+    const authParams = getAuthParams(request)
+    const resourceType = request.route.path.split('/')[2]
+    const resourceBuilder = config.get('AuthConfig.resources')[resourceType]
+
+    if (!resourceBuilder) {
+      return reply(Boom.badImplentation('Resource builder not found'))
+    }
+
+    const tasks = teams.map(function (team) {
+      const params = {
+        userId: currentUser.id,
+        teamId: team,
+        organizationId: currentUser.organizationId
+      }
+      const resource = resourceBuilder(params)
+      const { action } = authParams
+
+      return function check (callback) {
+        server.app.udaru.authorize.isUserAuthorized({ userId: currentUser.id, action, resource, organizationId: currentUser.organizationId }, (err, result) => {
+          if (err || !result || !result.access) return callback(err || new Error(`Not enough permissions to modify team ${team}`))
+          callback()
+        })
+      }
+    })
+
+    async.series(tasks, function (err) {
+      if (err) return reply(err.isBoom ? err : Boom.forbidden(err))
+
+      reply.continue()
+    })
+  })
+}
+
+function authorize (server, settings, request, reply) {
+  const req = request.raw.req
+
+  const authorization = req.headers.authorization
+  if (!authorization) {
+    return reply(Boom.unauthorized('Missing authorization', 'udaru'))
+  }
+
+  const userId = String(authorization)
+
+  settings.validateFunc(server, request, userId, (err, credentials) => {
+    if (err) return reply(err)
+
+    request.udaru = credentials
+
+    return reply.continue({ credentials: { scope: 'udaru' } })
+  })
+}
+
+module.exports = {
+  getAuthParams,
+  needTeamsValidation,
+  validateTeamsInPayload,
+  authorize
+}

--- a/lib/plugin/security/hapi-auth-service.js
+++ b/lib/plugin/security/hapi-auth-service.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const Boom = require('boom')
 const Hoek = require('hoek')
+const authorization = require('./authorization')
 
 const internals = {}
 
@@ -23,23 +23,20 @@ internals.implementation = function (server, options) {
   const settings = Hoek.clone(options)
 
   const scheme = {
-    authenticate: function (request, reply) {
-      const req = request.raw.req
+    authenticate: function authenticate (request, reply) {
+      authorization.authorize(server, settings, request, reply)
+    },
 
-      const authorization = req.headers.authorization
-      if (!authorization) {
-        return reply(Boom.unauthorized('Missing authorization', 'udaru'))
+    payload: function payload (request, reply) {
+      if (authorization.needTeamsValidation(request)) {
+        return authorization.validateTeamsInPayload(server, request, reply)
       }
 
-      const userId = String(authorization)
+      reply.continue()
+    },
 
-      settings.validateFunc(server, request, userId, (err, credentials) => {
-        if (err) return reply(err)
-
-        request.udaru = credentials
-
-        return reply.continue({ credentials: { scope: 'udaru' } })
-      })
+    options: {
+      payload: true
     }
   }
 

--- a/lib/plugin/security/hapi-auth-validation.js
+++ b/lib/plugin/security/hapi-auth-validation.js
@@ -3,6 +3,7 @@
 const async = require('async')
 const Boom = require('boom')
 const config = require('../config')
+const authorization = require('./authorization')
 
 function canImpersonate (options, user) {
   return user.organizationId === config.get('authorization.superUser.organization.id')
@@ -107,7 +108,7 @@ function authorize (job, next) {
 }
 
 module.exports = (options, server, request, userId, callback) => {
-  const authParams = request.route.settings.plugins && request.route.settings.plugins.auth
+  const authParams = authorization.getAuthParams(request)
 
   if (!authParams) {
     return callback(Boom.forbidden('Invalid credentials', 'udaru'))

--- a/test/integration/endToEnd/users.test.js
+++ b/test/integration/endToEnd/users.test.js
@@ -576,3 +576,47 @@ lab.experiment('Users - checking org_id scoping', () => {
     })
   })
 })
+
+lab.experiment('Users - manage teams', () => {
+  lab.test('replace users teams', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users/ModifyId/teams',
+      payload: {
+        teams: ['2', '3']
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.id).to.equal('ModifyId')
+      expect(result.teams).to.equal([{ id: '3', name: 'Authors' }, { id: '2', name: 'Readers' }])
+
+      udaru.users.deleteTeams({ id: result.id, organizationId: result.organizationId, teams: [] }, done)
+    })
+  })
+
+  lab.test('Delete user from her teams', (done) => {
+    udaru.users.replaceTeams({ id: 'ModifyId', organizationId: 'WONKA', teams: ['2', '3'] }, (err, user) => {
+      if (err) return done(err)
+
+      const options = utils.requestOptions({
+        method: 'DELETE',
+        url: '/authorization/users/ModifyId/teams'
+      })
+
+      server.inject(options, (response) => {
+        const result = response.result
+
+        expect(response.statusCode).to.equal(200)
+        expect(result.id).to.equal('ModifyId')
+        expect(result.teams).to.equal([])
+
+        done()
+      })
+    })
+  })
+})
+


### PR DESCRIPTION
This PR adds two new endpoint:

* `POST /users/{id}/teams` to replace user's teams
* `DELETE /users/{id}/teams` to remove user from all her teams

The tricky operation here was checking that the caller had the right permission on all teams because if the caller is not allowed to manipulate a user inside a certain team the operation should fail.

To achieve this we had to add a new function in the auth scheme object: `payload` (doc [here](https://github.com/hapijs/hapi/blob/master/API.md#serverauthschemename-scheme)). We need that function because we will get the teams (for `POST /users/{id}/teams`) from the request payload, but [the payload is not yet parsed when the `authenticate` function is called](http://freecontent.manning.com/hapi-js-in-action-diagram/).

This PR add also a new module [`security/authorization.js`](https://github.com/nearform/labs-authorization/pull/352/files#diff-b3f492fb6f54bce8eb2480a0eaf72afdR1). It contains `authenticate` and `payload`, and all the logic for the latter. In my idea it should eventually have all the logic of our middleware and expose only `authenticate`, `payload` and maybe some helper functions (to be used in `hapi-auth-validation.js`).

Ref. issue #311