### PR TITLE
Issue 360 existing organization id error

### DIFF
--- a/lib/core/lib/ops/organizationOps.js
+++ b/lib/core/lib/ops/organizationOps.js
@@ -115,7 +115,11 @@ function insertOrganization (job, next) {
     RETURNING id
   `
   job.client.query(sqlQuery, function (err, res) {
+    if (utils.isUniqueViolationError(err)) {
+      return next(Boom.badRequest(`Organization with id ${id} already present`))
+    }
     if (err) return next(Boom.badImplementation(err))
+
     job.organization = res.rows[0]
     next()
   })

--- a/lib/core/lib/ops/userOps.js
+++ b/lib/core/lib/ops/userOps.js
@@ -188,7 +188,7 @@ const userOps = {
 
       userOps.organizationExists(organizationId, (err, res) => {
         if (err) return cb(Boom.badImplementation(err))
-        if (!res) return cb(Boom.badRequest(`Organization '${organizationId}' does not exists`))
+        if (!res) return cb(Boom.badRequest(`Organization '${organizationId}' does not exist`))
 
         userOps.insertUser(db, { id, name, organizationId }, (err, result) => {
           if (err) return cb(err)

--- a/lib/core/lib/ops/validation.js
+++ b/lib/core/lib/ops/validation.js
@@ -7,10 +7,10 @@ const requiredStringId = Joi.string().required().max(128)
 
 const validationRules = {
   name: requiredString.description('Name'),
-  userName: requiredString.description('Name'),
-  teamName: requiredString.description('Name'),
-  policyName: requiredString.description('Name'),
-  organizationName: requiredString.description('Name'),
+  userName: requiredString.max(50).description('Name'),
+  teamName: requiredString.max(30).description('Name'),
+  policyName: requiredString.max(64).description('Name'),
+  organizationName: requiredString.max(64).description('Name'),
   description: requiredString.description('Description'),
   userId: requiredStringId.description('User ID'),
   teamId: requiredStringId.description('Team ID'),

--- a/lib/core/lib/ops/validation.js
+++ b/lib/core/lib/ops/validation.js
@@ -3,12 +3,18 @@
 const Joi = require('joi')
 
 const requiredString = Joi.string().required()
+const requiredStringId = Joi.string().required().max(128)
 
 const validationRules = {
-  id: Joi.string().required(),
   name: requiredString.description('Name'),
+  userName: requiredString.description('Name'),
+  teamName: requiredString.description('Name'),
+  policyName: requiredString.description('Name'),
+  organizationName: requiredString.description('Name'),
   description: requiredString.description('Description'),
-  organizationId: requiredString.description('Organization ID'),
+  userId: requiredStringId.description('User ID'),
+  teamId: requiredStringId.description('Team ID'),
+  organizationId: requiredStringId.description('Organization ID'),
   page: Joi.number().integer().min(1).description('Page number, starts from 1'),
   limit: Joi.number().integer().min(1).description('Items per page'),
   version: requiredString.description('Version number'),
@@ -44,49 +50,49 @@ const users = {
     organizationId: validationRules.organizationId
   },
   readUser: {
-    id: validationRules.id.description('User ID'),
+    id: validationRules.userId,
     organizationId: validationRules.organizationId
   },
   createUser: {
-    id: validationRules.id.optional().description('User ID'),
-    name: validationRules.name,
+    id: validationRules.userId.optional(),
+    name: validationRules.userName,
     organizationId: validationRules.organizationId
   },
   deleteUser: {
-    id: validationRules.id.description('User ID'),
+    id: validationRules.userId,
     organizationId: validationRules.organizationId
   },
   updateUser: {
-    id: validationRules.id.description('User ID'),
-    name: validationRules.name,
+    id: validationRules.userId,
+    name: validationRules.userName,
     organizationId: validationRules.organizationId
   },
   replaceUserPolicies: {
-    id: validationRules.id.description('User ID'),
+    id: validationRules.userId,
     policies: validationRules.policies,
     organizationId: validationRules.organizationId
   },
   addUserPolicies: {
-    id: validationRules.id.description('User ID'),
+    id: validationRules.userId,
     policies: validationRules.policies,
     organizationId: validationRules.organizationId
   },
   deleteUserPolicies: {
-    id: validationRules.id.description('User ID'),
+    id: validationRules.userId,
     organizationId: validationRules.organizationId
   },
   deleteUserPolicy: {
-    userId: validationRules.id.description('User ID'),
+    userId: validationRules.userId,
     policyId: validationRules.policyId,
     organizationId: validationRules.organizationId
   },
   replaceUserTeams: {
-    id: validationRules.id.description('User ID'),
+    id: validationRules.userId,
     teams: validationRules.teams,
     organizationId: validationRules.organizationId
   },
   deleteUserFromTeams: {
-    id: validationRules.id.description('User ID'),
+    id: validationRules.userId,
     organizationId: validationRules.organizationId
   }
 }
@@ -99,73 +105,73 @@ const teams = {
   },
   createTeam: {
     id: Joi.string().regex(/^[0-9a-zA-Z_]+$/).description('The ID to be used for the new team. Only alphanumeric characters and underscore are supported'),
-    parentId: Joi.any(),
-    name: requiredString.description('Team name'),
+    parentId: validationRules.teamId.optional().allow(null),
+    name: validationRules.teamName,
     description: validationRules.description,
     user: validationRules.user,
     organizationId: validationRules.organizationId
   },
   readTeam: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     organizationId: validationRules.organizationId
   },
   updateTeam: {
-    id: validationRules.id.description('Team ID'),
-    name: validationRules.name.optional(),
+    id: validationRules.teamId,
+    name: validationRules.teamName.optional(),
     description: validationRules.description.optional(),
     organizationId: validationRules.organizationId
   },
   deleteTeam: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     organizationId: validationRules.organizationId
   },
   moveTeam: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     parentId: validationRules.parentId,
     organizationId: validationRules.organizationId
   },
   addTeamPolicies: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     policies: validationRules.policies,
     organizationId: validationRules.organizationId
   },
   replaceTeamPolicies: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     policies: validationRules.policies,
     organizationId: validationRules.organizationId
   },
   deleteTeamPolicies: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     organizationId: validationRules.organizationId
   },
   deleteTeamPolicy: {
-    teamId: validationRules.id.description('Team ID'),
+    teamId: validationRules.teamId,
     policyId: validationRules.policyId,
     organizationId: validationRules.organizationId
   },
   readTeamUsers: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     page: validationRules.page,
     limit: validationRules.limit,
     organizationId: validationRules.organizationId
   },
   addUsersToTeam: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     users: validationRules.users,
     organizationId: validationRules.organizationId
   },
   replaceUsersInTeam: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     users: validationRules.users,
     organizationId: validationRules.organizationId
   },
   deleteTeamMembers: {
-    id: validationRules.id.description('Team ID'),
+    id: validationRules.teamId,
     organizationId: validationRules.organizationId
   },
   deleteTeamMember: {
-    id: validationRules.id.description('Team ID'),
-    userId: validationRules.id.description('User ID'),
+    id: validationRules.teamId,
+    userId: validationRules.userId,
     organizationId: validationRules.organizationId
   }
 }
@@ -177,25 +183,25 @@ const policies = {
     limit: validationRules.limit
   },
   readPolicy: {
-    id: validationRules.id.description('Policy ID'),
+    id: validationRules.policyId,
     organizationId: validationRules.organizationId
   },
   createPolicy: {
-    id: Joi.string().allow('').description('policy id'),
+    id: Joi.string().allow('').description('Policy ID'),
     version: validationRules.version,
-    name: validationRules.name,
+    name: validationRules.policyName,
     organizationId: validationRules.organizationId,
     statements: validationRules.statements
   },
   updatePolicy: {
-    id: validationRules.id.description('Policy ID'),
+    id: validationRules.policyId,
     organizationId: validationRules.organizationId,
     version: validationRules.version,
-    name: validationRules.name,
+    name: validationRules.policyName,
     statements: validationRules.statements
   },
   deletePolicy: {
-    id: validationRules.id.description('Policy ID'),
+    id: validationRules.policyId,
     organizationId: validationRules.organizationId
   }
 }
@@ -207,15 +213,15 @@ const organizations = {
   },
   readById: validationRules.organizationId,
   create: {
-    id: Joi.string().description('Organization ID'),
-    name: validationRules.name,
+    id: validationRules.organizationId.optional(),
+    name: validationRules.organizationName,
     description: validationRules.description,
     user: validationRules.user
   },
   deleteById: validationRules.organizationId,
   update: {
     id: validationRules.organizationId,
-    name: validationRules.name,
+    name: validationRules.organizationName,
     description: validationRules.description
   },
   addOrganizationPolicies: {
@@ -237,13 +243,13 @@ const organizations = {
 
 const authorize = {
   isUserAuthorized: {
-    userId: validationRules.id.description('User ID'),
+    userId: validationRules.userId,
     action: requiredString.description('The action to check'),
     resource: requiredString.description('The resource that the user wants to perform the action on'),
     organizationId: validationRules.organizationId
   },
   listAuthorizations: {
-    userId: validationRules.id.description('User ID'),
+    userId: validationRules.userId,
     resource: requiredString.description('The resource that the user wants to perform the action on'),
     organizationId: validationRules.organizationId
   }

--- a/test/integration/endToEnd/users.test.js
+++ b/test/integration/endToEnd/users.test.js
@@ -157,7 +157,7 @@ lab.experiment('Users - create', () => {
       expect(response.statusCode).to.equal(400)
       expect(result).to.equal({
         error: 'Bad Request',
-        message: `Organization 'DOES_NOT_EXISTS' does not exists`,
+        message: `Organization 'DOES_NOT_EXISTS' does not exist`,
         statusCode: 400
       })
 

--- a/test/integration/organizationOps.test.js
+++ b/test/integration/organizationOps.test.js
@@ -189,6 +189,17 @@ lab.experiment('OrganizationOps', () => {
     })
   })
 
+  lab.test('create an organization with long name should fail', (done) => {
+    const orgName = Array(66).join('a')
+    udaru.organizations.create({ id: 'nearForm', name: orgName, description: 'nearform description' }, (err, result) => {
+      expect(err).to.exist()
+      expect(err.output.statusCode).to.equal(400)
+      expect(err.message).to.match(/length must be less than/)
+
+      done()
+    })
+  })
+
   lab.test('update an organization', (done) => {
     const createData = { id: 'nearForm1', name: 'nearForm', description: 'nearform description' }
     const updateData = { id: 'nearForm1', name: 'nearFormUp', description: 'nearFormUp desc up', policies: [] }

--- a/test/integration/organizationOps.test.js
+++ b/test/integration/organizationOps.test.js
@@ -104,6 +104,27 @@ lab.experiment('OrganizationOps', () => {
     })
   })
 
+  lab.test('create twice an organization with the same id should fail second time', (done) => {
+    const organizationData = {
+      id: 'nearForm',
+      name: 'nearForm',
+      description: 'nearForm description'
+    }
+    udaru.organizations.create(organizationData, { createOnly: true }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result.organization).to.exist()
+      expect(result.organization.name).to.equal('nearForm')
+
+      udaru.organizations.create(organizationData, { createOnly: true }, (err, result) => {
+        expect(err).to.exist()
+        expect(err.output.statusCode).to.equal(400)
+        expect(err.message).to.match(/Organization with id nearForm already present/)
+
+        udaru.organizations.delete(organizationData.id, done)
+      })
+    })
+  })
+
   lab.test('create an organization specifying a user should create the user and assign the OrgAdmin policy to it', (done) => {
     udaru.organizations.create({
       id: 'nearForm',

--- a/test/integration/policyOps.test.js
+++ b/test/integration/policyOps.test.js
@@ -105,6 +105,17 @@ lab.experiment('PolicyOps', () => {
     })
   })
 
+  lab.test('create a policy with long name should fail', (done) => {
+    const policyName = Array(66).join('a')
+    udaru.policies.create({ organizationId: 'WONKA', name: policyName, id: 'longtestid', version: '1', statements }, (err, result) => {
+      expect(err).to.exist()
+      expect(err.output.statusCode).to.equal(400)
+      expect(err.message).to.match(/length must be less than/)
+
+      done()
+    })
+  })
+
   lab.experiment('listAllUserPolicies', () => {
     const records = Factory(lab, {
       teams: {

--- a/test/integration/policyOps.test.js
+++ b/test/integration/policyOps.test.js
@@ -105,6 +105,29 @@ lab.experiment('PolicyOps', () => {
     })
   })
 
+  lab.test('create policy with duplicate id should fail', (done) => {
+    const policyData = {
+      id: 'MyDuplicateId',
+      version: '1',
+      name: 'Documents Admin',
+      organizationId: 'WONKA',
+      statements
+    }
+
+    udaru.policies.create(policyData, (err, policy) => {
+      expect(err).to.not.exist()
+      expect(policy).to.exist()
+
+      udaru.policies.create(policyData, (err, policy) => {
+        expect(err).to.exist()
+        expect(err.output.statusCode).to.equal(400)
+        expect(err.message).to.match(/Policy with id MyDuplicateId already present/)
+
+        udaru.policies.delete({ id: policyData.id, organizationId: 'WONKA' }, done)
+      })
+    })
+  })
+
   lab.test('create a policy with long name should fail', (done) => {
     const policyName = Array(66).join('a')
     udaru.policies.create({ organizationId: 'WONKA', name: policyName, id: 'longtestid', version: '1', statements }, (err, result) => {

--- a/test/integration/security/sqlinjection.test.js
+++ b/test/integration/security/sqlinjection.test.js
@@ -107,13 +107,7 @@ lab.experiment('get users SQL injection tests', () => {
     options.headers.org = org
 
     server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result.page).to.equal(1)
-      expect(result.limit).to.equal(3)
-      expect(result.total).to.equal(0)
-      expect(result.data.length).to.equal(0)
+      expect(response.statusCode).to.equal(400)
 
       done()
     })

--- a/test/integration/teamOps.test.js
+++ b/test/integration/teamOps.test.js
@@ -249,6 +249,28 @@ lab.experiment('TeamOps', () => {
     })
   })
 
+  lab.test('creating a team with the same id should fail second time', (done) => {
+    let testTeam = {
+      id: 'nearForm',
+      name: 'nearForm',
+      description: 'description',
+      organizationId: 'WONKA'
+    }
+
+    udaru.teams.create(testTeam, {createOnly: true}, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.exist()
+
+      udaru.teams.create(testTeam, {createOnly: true}, (err, result) => {
+        expect(err).to.exist()
+        expect(err.output.statusCode).to.equal(400)
+        expect(err.message).to.match(/Team with id nearForm already present/)
+
+        udaru.teams.delete(testTeam, done)
+      })
+    })
+  })
+
   lab.test('create a team with long name should fail', (done) => {
     const teamName = Array(32).join('a')
     udaru.teams.create({ organizationId: 'WONKA', name: teamName, description: 'nearform description' }, (err, result) => {

--- a/test/integration/teamOps.test.js
+++ b/test/integration/teamOps.test.js
@@ -249,6 +249,17 @@ lab.experiment('TeamOps', () => {
     })
   })
 
+  lab.test('create a team with long name should fail', (done) => {
+    const teamName = Array(32).join('a')
+    udaru.teams.create({ organizationId: 'WONKA', name: teamName, description: 'nearform description' }, (err, result) => {
+      expect(err).to.exist()
+      expect(err.output.statusCode).to.equal(400)
+      expect(err.message).to.match(/length must be less than/)
+
+      done()
+    })
+  })
+
   lab.test('create team support creation of default team admin user', (done) => {
     let teamId = randomId()
     let testTeam = {

--- a/test/integration/userOps.test.js
+++ b/test/integration/userOps.test.js
@@ -60,6 +60,17 @@ lab.experiment('UserOps', () => {
     })
   })
 
+  lab.test('create a user with long name should fail', (done) => {
+    const userName = Array(52).join('a')
+    udaru.users.create({ organizationId: 'WONKA', name: userName, id: 'longtestid' }, (err, result) => {
+      expect(err).to.exist()
+      expect(err.output.statusCode).to.equal(400)
+      expect(err.message).to.match(/length must be less than/)
+
+      done()
+    })
+  })
+
   lab.test('create and delete a user without specifying an id', (done) => {
     const userData = {
       name: 'Mike Teavee',

--- a/test/integration/userOps.test.js
+++ b/test/integration/userOps.test.js
@@ -60,6 +60,26 @@ lab.experiment('UserOps', () => {
     })
   })
 
+  lab.test('create an user with the same id should fail second time', (done) => {
+    const userData = {
+      id: 'testId',
+      name: 'Mike Teavee',
+      organizationId: 'WONKA'
+    }
+    udaru.users.create(userData, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.exist()
+
+      udaru.users.create(userData, (err, result) => {
+        expect(err).to.exist()
+        expect(err.output.statusCode).to.equal(400)
+        expect(err.message).to.match(/User with id testId already present/)
+
+        udaru.users.delete({ id: 'testId', organizationId: 'WONKA' }, done)
+      })
+    })
+  })
+
   lab.test('create a user with long name should fail', (done) => {
     const userName = Array(52).join('a')
     udaru.users.create({ organizationId: 'WONKA', name: userName, id: 'longtestid' }, (err, result) => {


### PR DESCRIPTION
Implements: https://github.com/nearform/labs-authorization/issues/360

- Cleaned up the Joi validation file,
- Added Joi validation and tests for the Name field on orgs, users, teams and policies,
- Team parent id Joi validation,
- Added 400 bad request for cases when trying to create element with existing id. Added tests and error creation for orgs, users, teams and policies.