### PR TITLE
SuperUsers with limited access across organizations

### DIFF
--- a/docs/authmodel.md
+++ b/docs/authmodel.md
@@ -1,0 +1,58 @@
+# Examples of organization structures modeled with Udaru
+
+Access to resources can be modeled in Udaru through the elements that it provides: Organizations, Teams, Users. Policies can be attached to any of these elements.
+See more details in the [Authorization Introduction][]
+
+The usual modeling case is to build independent organizations, each organization having teams (or nested teams) attached to them and users attached to teams. Policies are attached to Organizations, Teams or Users.
+
+In the examples below in the **Cross organization access management** section it is described a particular case in which we need users that have access rights over several organizations, this corner case not matching exactly the Udary modeling architecture.
+
+## Cross organization access management
+
+This example describes how to model an organization in which it is needed to have users that have access rights over several organizations and have limited access rights on other organizations.
+
+### Context
+
+In Udaru all operations are performed in the organization context: for each user request Udaru finds the organization to which the user belongs to and from there all middleware checks and element queries are made in the organization context. One user can't perform operations outside the organization to which it belongs to. The user identifier is passed in the Http headers as the `authorization` field.
+
+There is a special type of Udaru users, named SuperUsers, that belong to the 'ROOT' organization. SuperUsers can be assigned full access rights on all actions on all resources. To be able to do operations as SuperUser on an Organization, Udaru provides an impersonation functionality: by passing in the Http headers an 'org' field, the endpoint request is made as if the SuperUser belongs to the 'org' organization thus having acess to all the exposed Udaru functionality for that organization (like user management, team management).
+
+curl impersonation example in which a SuperUser impersonates an user belonging to the `WONKA` organization:
+```javascript
+curl -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'authorization: ROOTID' --header 'org: WONKA' -d '{"policies":["PolicyID"]}' 'http://localhost:8080/authorization/teams/TeamID/policies'
+```
+
+### Needed model structure
+
+The structure to be modeled is the following:
+
+We have the default root organization on which we have two Teams. On the first team there are two users, on the 2nd team there is one user and the 4th user belongs to no team. All the 4 users belong to the root organization.
+We plan to add to Team1 a set of policies so ithat the User1 and User2 have access to resources from Org1 and Org2, then assign to Team2 a set of policies so that User3 has access to Org3. User4 has no policies attached and has no access to any of the Organizations.
+
+A visual representation of the structure:
+```
+  -------------------   --------   --------   --------
+  |     rootOrg     |   | Org1 |   | Org2 |   | Org3 |
+  -------------------   --------   --------   --------
+     /        \   \
+   Team1     Team2 \
+   /   \       |    \
+ User1 User2 User3  User4
+```
+
+### Solution
+
+One **limitation** of this modelling approach is that we have to build the route access policies and also the resource access policies in the root organization so that they can be attached to the SuperUser teams. The policy management is made at the root organization level.
+
+The structure is build like it is described in the previous section.
+The organization endpoints access policies and organization resource access policies are attached to the two teams.
+
+A fully working model sample can be seen in the [Full organization test file][] in the "SuperUsers with limited acces across organizations" Experiment.
+
+The policies built to configure access structure are of three types:
+- Access to organization management operations is given by attaching to the two root teams the default organization policies: `authorization:organizations:read`, `authorization:teams:*`, `authorization:users:*`, `authorization:policies:list`, `authorization:policies:read`,
+- Access to the authorization endpoints is given by attaching to teams a policy that gives `authorization:authn:access` to the `authorization/access` resource,
+- Access to internal organization policies is given by defining specific internal organization actions and resources.
+
+[Authorization Introduction]: authorization-introduction.md
+[Full organization test file]: ../test/integration/endToEnd/fullOrgStructure.test.js

--- a/docs/authmodel.md
+++ b/docs/authmodel.md
@@ -5,7 +5,7 @@ See more details in the [Authorization Introduction][]
 
 The usual modeling case is to build independent organizations, each organization having teams (or nested teams) attached to them and users attached to teams. Policies are attached to Organizations, Teams or Users.
 
-In the examples below in the **Cross organization access management** section it is described a particular case in which we need users that have access rights over several organizations, this corner case not matching exactly the Udary modeling architecture.
+In the examples below in the **Cross organization access management** section it is described a particular case in which we need users that have access rights over several organizations. This corner case is not the perfect match for the Udaru architecture but it can be achieved using the shallow impersonation feature.
 
 ## Cross organization access management
 
@@ -27,7 +27,7 @@ curl -X PUT --header 'Content-Type: application/json' --header 'Accept: applicat
 The structure to be modeled is the following:
 
 We have the default root organization on which we have two Teams. On the first team there are two users, on the 2nd team there is one user and the 4th user belongs to no team. All the 4 users belong to the root organization.
-We plan to add to Team1 a set of policies so ithat the User1 and User2 have access to resources from Org1 and Org2, then assign to Team2 a set of policies so that User3 has access to Org3. User4 has no policies attached and has no access to any of the Organizations.
+We plan to add to Team1 a set of policies so that the User1 and User2 have access to resources from Org1 and Org2, then assign to Team2 a set of policies so that User3 has access to Org3. User4 has no policies attached and has no access to any of the Organizations.
 
 A visual representation of the structure:
 ```
@@ -50,8 +50,8 @@ The organization endpoints access policies and organization resource access poli
 A fully working model sample can be seen in the [Full organization test file][] in the "SuperUsers with limited acces across organizations" Experiment.
 
 The policies built to configure access structure are of three types:
-- Access to organization management operations is given by attaching to the two root teams the default organization policies: `authorization:organizations:read`, `authorization:teams:*`, `authorization:users:*`, `authorization:policies:list`, `authorization:policies:read`,
-- Access to the authorization endpoints is given by attaching to teams a policy that gives `authorization:authn:access` to the `authorization/access` resource,
+- Access to organization management operations is given by attaching to the two root teams the default organization policies: `authorization:organizations:read` rights to be able to access the `/authorization/organizations/<orgId>` endpoint, `authorization:teams:*` rights to allow access to `/authorization/teams/*` endpoints, `authorization:users:*` rights to allow access to `/authorization/users/*` endpoints, `authorization:policies:list` rights to access the `/authorization/policies` endpoint, `authorization:policies:read` rights to access the `/authorization/policies/<policyId>` endpoint,
+- Access to the authorization check endpoint is given by attaching to teams a policy that gives `authorization:authn:access` rights to allow access on `/authorization/access/{userId}/{action}/{resource*}` endpoint,
 - Access to internal organization policies is given by defining specific internal organization actions and resources.
 
 [Authorization Introduction]: authorization-introduction.md

--- a/docs/authorization-introduction.md
+++ b/docs/authorization-introduction.md
@@ -20,7 +20,7 @@ Altough the [AWS IAM Policy][] is not the documentation for [node-pbac][] it can
 
 An access control model can be built using the **Organization**, **Team** and **User** entities. The Organizations can contain Teams or Users and the Teams can contain other Teams or Users. Note: only the Team elements can contain other Team elements (same type elements).
 
-**Policies** can be attached to Teams and Users. The policy engine evaluates all policies from all levels when establishing if an User can perform an Action over a Resource. Currently there is no functionality provided to attach Policies to Organizations although the current database structure supports it.
+**Policies** can be attached to Teams, Users and Organizations. The policy engine evaluates all policies from all levels when establishing if an User can perform an Action over a Resource.
 
 **Important note:** Teams, Users and Policies can't be shared across Organizations.
 

--- a/test/integration/endToEnd/fullOrgStructure.test.js
+++ b/test/integration/endToEnd/fullOrgStructure.test.js
@@ -1,0 +1,156 @@
+'use strict'
+
+const expect = require('code').expect
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+
+const config = require('../../../lib/plugin/config')
+const server = require('../../../lib/server')
+const Factory = require('../../factory')
+const utils = require('../../utils')
+
+lab.experiment('SuperUsers with limited access across organizations', () => {
+  const rootOrgId = config.get('authorization.superUser.organization.id')
+  const orgId1 = 'orgId1'
+  const orgId2 = 'orgId2'
+  const orgId3 = 'orgId3'
+
+  const teamId1 = 'teamId1'
+  const teamId2 = 'teamId2'
+
+  const userId1 = 'userId1'
+  const userId2 = 'userId2'
+  const userId3 = 'userId3'
+  const userId4 = 'userId4'
+
+  const records = Factory(lab, {
+    organizations: {
+      // rootOrg: {
+      //   id: rootOrgId,
+      //   name: 'root org',
+      //   description: 'root org'
+      // },
+      org1: {
+        id: orgId1,
+        name: 'org1',
+        description: 'org1'
+      },
+      org2: {
+        id: orgId2,
+        name: 'org2',
+        description: 'org2'
+      },
+      org3: {
+        id: orgId3,
+        name: 'org3',
+        description: 'org3'
+      }
+    },
+    teams: {
+      team1: {
+        id: teamId1,
+        name: 'team1',
+        description: 'team1',
+        organizationId: rootOrgId,
+        users: ['user1', 'user2'],
+        policies: ['org1AdminPolicy', 'org2AdminPolicy']
+      },
+      team2: {
+        id: teamId2,
+        name: 'team2',
+        description: 'team2',
+        organizationId: rootOrgId,
+        users: ['user3'],
+        policies: ['org3AdminPolicy']
+      }
+    },
+    users: {
+      user1: {
+        id: userId1,
+        name: 'user1',
+        organizationId: rootOrgId
+      },
+      user2: {
+        id: userId2,
+        name: 'user2',
+        organizationId: rootOrgId
+      },
+      user3: {
+        id: userId3,
+        name: 'user3',
+        organizationId: rootOrgId
+      },
+      user4: {
+        id: userId4,
+        name: 'user4',
+        organizationId: rootOrgId
+      }
+    },
+    policies: {
+      org1AdminPolicy: {
+        name: 'org1AdminPolicy',
+        organizationId: rootOrgId,
+        statements: utils.AllowStatement('action:user:read', 'resource:user')
+      },
+      org2AdminPolicy: {
+        name: 'org2AdminPolicy',
+        organizationId: rootOrgId,
+        statements: utils.AllowStatement('action:team:read', 'resource:team')
+      },
+      org3AdminPolicy: {
+        name: 'org3AdminPolicy',
+        organizationId: rootOrgId,
+        statements: utils.AllowStatement('action:team:read', 'resource:team')
+      },
+      org1InternalPolicy: {
+        name: 'org1InternalPolicy',
+        organizationId: orgId1,
+        statements: utils.AllowStatement('action:organization1:read', 'resource:organization1')
+      },
+      org2InternalPolicy: {
+        name: 'org2InternalPolicy',
+        organizationId: orgId2,
+        statements: utils.AllowStatement('action:organization2:read', 'resource:organization2')
+      },
+      org3InternalPolicy: {
+        name: 'org3InternalPolicy',
+        organizationId: orgId3,
+        statements: utils.AllowStatement('action:organization3:read', 'resource:organization3')
+      }
+    }
+  })
+
+  lab.experiment('Check limited super users organization management rights', () => {
+    lab.test('List teams and users on an org on which it has rights', (done) => {
+      done()
+      // const options = utils.requestOptions({
+      //   method: 'GET',
+      //   url: '/authorization/organizations'
+      // })
+
+      // server.inject(options, (response) => {
+      //   expect(response.statusCode).to.equal(200)
+      //   expect(response.result).to.exist()
+      //   expect(response.result.page).to.equal(1)
+      //   expect(response.result.total).greaterThan(1)
+      //   expect(response.result.limit).greaterThan(1)
+      //   done()
+      // })
+    })
+
+    lab.test('List teams and users on an org on which it has no rights', (done) => {
+      done()
+    })
+
+    lab.test('Add team and user on an org on which has rights', (done) => {
+      done()
+    })
+
+    lab.test('Add team and user on an org on which it has no rights', (done) => {
+      done()
+    })
+  })
+
+  lab.experiment('Check limited super users rights on accessing organization resources', () => {
+  })
+})

--- a/test/utils.js
+++ b/test/utils.js
@@ -35,19 +35,19 @@ function deleteUserFromAllTeams (id, cb) {
 function Statement (effect, action, resource) {
   return {
     Statement: [{
-      Effect: 'Allow',
-      Action: [action],
-      Resource: [resource]
+      Effect: effect,
+      Action: action,
+      Resource: resource
     }]
   }
 }
 
 function DenyStatement (action, resource) {
-  return Statement('Allow', action, resource)
+  return Statement('Deny', action, resource)
 }
 
 function AllowStatement (action, resource) {
-  return Statement('Deny', action, resource)
+  return Statement('Allow', action, resource)
 }
 
 module.exports = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -32,10 +32,31 @@ function deleteUserFromAllTeams (id, cb) {
   db.query(sqlQuery, cb)
 }
 
+function Statement (effect, action, resource) {
+  return {
+    Statement: [{
+      Effect: 'Allow',
+      Action: [action],
+      Resource: [resource]
+    }]
+  }
+}
+
+function DenyStatement (action, resource) {
+  return Statement('Allow', action, resource)
+}
+
+function AllowStatement (action, resource) {
+  return Statement('Deny', action, resource)
+}
+
 module.exports = {
   requestOptions,
   findPick,
   deleteUserFromAllTeams,
   udaru,
-  db
+  db,
+  Statement,
+  AllowStatement,
+  DenyStatement
 }


### PR DESCRIPTION
First draft of sample code and documentation that shows how to model two teams of SuperUsers that through their attached policies limit the SuperUser access across organizations.

/cc @p16 