### PR TITLE
increase user.name length, fix org_policies.org_id

### DIFF
--- a/database/migrations/003.do.sql
+++ b/database/migrations/003.do.sql
@@ -1,0 +1,6 @@
+
+ALTER TABLE users
+  ALTER COLUMN name TYPE VARCHAR(255);
+
+ALTER TABLE organization_policies
+  ALTER COLUMN org_id TYPE VARCHAR(128);

--- a/database/migrations/003.undo.sql
+++ b/database/migrations/003.undo.sql
@@ -1,0 +1,6 @@
+
+ALTER TABLE users
+  ALTER COLUMN name TYPE VARCHAR(50);
+
+ALTER TABLE organization_policies
+  ALTER COLUMN org_id TYPE VARCHAR(20);

--- a/lib/core/lib/ops/validation.js
+++ b/lib/core/lib/ops/validation.js
@@ -7,7 +7,7 @@ const requiredStringId = Joi.string().required().max(128)
 
 const validationRules = {
   name: requiredString.description('Name'),
-  userName: requiredString.max(50).description('Name'),
+  userName: requiredString.max(255).description('Name'),
   teamName: requiredString.max(30).description('Name'),
   policyName: requiredString.max(64).description('Name'),
   organizationName: requiredString.max(64).description('Name'),
@@ -25,7 +25,7 @@ const validationRules = {
   }),
 
   parentId: Joi.string().description('Parent ID'),
-  policyId: requiredString.description('Policy ID'),
+  policyId: requiredStringId.description('Policy ID'),
 
   users: Joi.array().required().items(requiredString).description('User IDs'),
   policies: Joi.array().required().items(requiredString).description('Policies IDs'),
@@ -104,7 +104,7 @@ const teams = {
     organizationId: validationRules.organizationId
   },
   createTeam: {
-    id: Joi.string().regex(/^[0-9a-zA-Z_]+$/).description('The ID to be used for the new team. Only alphanumeric characters and underscore are supported'),
+    id: Joi.string().regex(/^[0-9a-zA-Z_]+$/).max(128).description('The ID to be used for the new team. Only alphanumeric characters and underscore are supported'),
     parentId: validationRules.teamId.optional().allow(null),
     name: validationRules.teamName,
     description: validationRules.description,
@@ -187,7 +187,7 @@ const policies = {
     organizationId: validationRules.organizationId
   },
   createPolicy: {
-    id: Joi.string().allow('').description('Policy ID'),
+    id: validationRules.policyId.allow('').optional(),
     version: validationRules.version,
     name: validationRules.policyName,
     organizationId: validationRules.organizationId,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "pg:init": "UDARU_SERVICE_local=true node database/init.js && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && npm run pg:load-test-data",
     "pg:load-test-data": "UDARU_SERVICE_local=true node database/loadTestData.js",
-    "pg:migrate": "node database/migrate.js --version=2",
+    "pg:migrate": "node database/migrate.js --version=3",
     "start": "node lib/server/start.js",
     "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 95",
     "test:commit-check": "npm run lint && npm run test"

--- a/test/integration/organizationOps.test.js
+++ b/test/integration/organizationOps.test.js
@@ -211,8 +211,19 @@ lab.experiment('OrganizationOps', () => {
   })
 
   lab.test('create an organization with long name should fail', (done) => {
-    const orgName = Array(66).join('a')
+    const orgName = 'a'.repeat(65)
     udaru.organizations.create({ id: 'nearForm', name: orgName, description: 'nearform description' }, (err, result) => {
+      expect(err).to.exist()
+      expect(err.output.statusCode).to.equal(400)
+      expect(err.message).to.match(/length must be less than/)
+
+      done()
+    })
+  })
+
+  lab.test('create an organization with long id should fail', (done) => {
+    const longId = 'a'.repeat(129)
+    udaru.organizations.create({ id: longId, name: 'nearform', description: 'nearform description' }, (err, result) => {
       expect(err).to.exist()
       expect(err.output.statusCode).to.equal(400)
       expect(err.message).to.match(/length must be less than/)

--- a/test/integration/policyOps.test.js
+++ b/test/integration/policyOps.test.js
@@ -129,8 +129,19 @@ lab.experiment('PolicyOps', () => {
   })
 
   lab.test('create a policy with long name should fail', (done) => {
-    const policyName = Array(66).join('a')
+    const policyName = 'a'.repeat(65)
     udaru.policies.create({ organizationId: 'WONKA', name: policyName, id: 'longtestid', version: '1', statements }, (err, result) => {
+      expect(err).to.exist()
+      expect(err.output.statusCode).to.equal(400)
+      expect(err.message).to.match(/length must be less than/)
+
+      done()
+    })
+  })
+
+  lab.test('create a policy with long id should fail', (done) => {
+    const longId = 'a'.repeat(129)
+    udaru.policies.create({ organizationId: 'WONKA', name: 'policyName', id: longId, version: '1', statements }, (err, result) => {
       expect(err).to.exist()
       expect(err.output.statusCode).to.equal(400)
       expect(err.message).to.match(/length must be less than/)

--- a/test/integration/teamOps.test.js
+++ b/test/integration/teamOps.test.js
@@ -272,8 +272,19 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('create a team with long name should fail', (done) => {
-    const teamName = Array(32).join('a')
+    const teamName = 'a'.repeat(31)
     udaru.teams.create({ organizationId: 'WONKA', name: teamName, description: 'nearform description' }, (err, result) => {
+      expect(err).to.exist()
+      expect(err.output.statusCode).to.equal(400)
+      expect(err.message).to.match(/length must be less than/)
+
+      done()
+    })
+  })
+
+  lab.test('create a team with long id should fail', (done) => {
+    const longId = 'a'.repeat(129)
+    udaru.teams.create({ id: longId, organizationId: 'WONKA', name: 'team name', description: 'nearform description' }, (err, result) => {
       expect(err).to.exist()
       expect(err.output.statusCode).to.equal(400)
       expect(err.message).to.match(/length must be less than/)

--- a/test/integration/userOps.test.js
+++ b/test/integration/userOps.test.js
@@ -81,7 +81,7 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('create a user with long name should fail', (done) => {
-    const userName = Array(52).join('a')
+    const userName = 'a'.repeat(256)
     udaru.users.create({ organizationId: 'WONKA', name: userName, id: 'longtestid' }, (err, result) => {
       expect(err).to.exist()
       expect(err.output.statusCode).to.equal(400)


### PR DESCRIPTION
Implements: https://github.com/nearform/labs-authorization/issues/374
Updates also the organization_policies.org_id field to 128 to match the organizations.id

/cc @marcopiraccini 