### PR TITLE
Issue 380 fix : move `postinstall` script to `presecurity:test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ To automatically run [sqlmap][] injection tests run:
 npm run test:security
 ```
 
--**Note**: before running this, make sure you have a version of [`Python 2.x`](https://www.python.org) installed in your path.
+- **Note:** before running this, make sure you have a version of [`Python 2.x`](https://www.python.org) installed in your path.
 
 These tests are not included in the main test suite. The security test spawns a hapi.js server exposing the Udaru routes. It only needs the DB to be running and being initialized with data.
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ To automatically run [sqlmap][] injection tests run:
 npm run test:security
 ```
 
+-**Note**: before running this, make sure you have a version of [`Python 2.x`](https://www.python.org) installed in your path.
+
 These tests are not included in the main test suite. The security test spawns a hapi.js server exposing the Udaru routes. It only needs the DB to be running and being initialized with data.
 
 The injection tests can be configured in the [sqlmap config][]. A few output configuration changes that can be made:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "bench": "node ./bench/util/runner.js",
     "test:security": "node ./security/runner.js",
-    "postinstall": "napa sqlmapproject/sqlmap",
+    "pretest:security": "napa sqlmapproject/sqlmap",
     "coverage": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 95 -r html -o docs/coverage.html",
     "coveralls": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 95 -r lcov | coveralls",
     "lint": "standard",


### PR DESCRIPTION
Fixes #380, but showed that #383 should be fixed as well for testing it on popular linux distributions ( at least `ubuntu`-based plus `arch`-based ones).